### PR TITLE
fix(material): remove duplicated readonly prop

### DIFF
--- a/src/material/input/src/input.type.ts
+++ b/src/material/input/src/input.type.ts
@@ -14,7 +14,6 @@ import { FieldType } from '@ngx-formly/material/form-field';
       [formControl]="formControl"
       [formlyAttributes]="field"
       [tabindex]="to.tabindex || 0"
-      [readonly]="to.readonly"
       [placeholder]="to.placeholder">
     <ng-template #numberTmp>
       <input matInput


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Quick fix, just removing a duplicate setting of the `readonly` prop on the material input type. doesn't create any side effect.