### PR TITLE
fix(material): add readonly and tabindex to number input

### DIFF
--- a/src/material/input/src/input.type.spec.ts
+++ b/src/material/input/src/input.type.spec.ts
@@ -1,0 +1,85 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FormlyFieldConfig, FormlyModule, FormlyFormOptions } from '@ngx-formly/core';
+import { FormlyFieldInput } from './input.type';
+
+@Component({
+  selector: 'formly-test',
+  template: `
+    <formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>
+  `,
+})
+class FormlyTestComponent {
+  form = new FormGroup({});
+  fields: FormlyFieldConfig[];
+  model: any;
+  options: FormlyFormOptions;
+}
+
+describe('ui-material: Formly Input Component', () => {
+  let fixture: ComponentFixture<FormlyTestComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [FormlyTestComponent, FormlyFieldInput],
+      imports: [
+        NoopAnimationsModule,
+        MatInputModule,
+        ReactiveFormsModule,
+        FormlyModule.forRoot({
+          types: [
+            {
+              name: 'input',
+              component: FormlyFieldInput,
+            },
+          ],
+        }),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormlyTestComponent);
+  });
+
+  it('should properly set the readonly value on text inputs', () => {
+    const componentInstance = fixture.componentInstance;
+    componentInstance.fields = [
+      {
+        key: 'name',
+        type: 'input',
+        templateOptions: {
+          readonly: true,
+        },
+      },
+    ];
+    fixture.detectChanges();
+
+    // assert
+    const inputField = fixture.debugElement.query(By.css('input'));
+    expect(inputField.nativeElement.getAttribute('readonly')).not.toBeNull();
+  });
+
+  it('should properly set the readonly value on number inputs', () => {
+    const componentInstance = fixture.componentInstance;
+    componentInstance.fields = [
+      {
+        key: 'name',
+        type: 'input',
+        templateOptions: {
+          type: 'number',
+          readonly: true,
+        },
+      },
+    ];
+    fixture.detectChanges();
+
+    // assert
+    const inputField = fixture.debugElement.query(By.css('input'));
+    expect(inputField.nativeElement.getAttribute('readonly')).not.toBeNull();
+  });
+});

--- a/src/material/input/src/input.type.ts
+++ b/src/material/input/src/input.type.ts
@@ -19,9 +19,11 @@ import { FieldType } from '@ngx-formly/material/form-field';
       <input matInput
              [id]="id"
              type="number"
+             [readonly]="to.readonly"
              [errorStateMatcher]="errorStateMatcher"
              [formControl]="formControl"
              [formlyAttributes]="field"
+             [tabindex]="to.tabindex || 0"
              [placeholder]="to.placeholder">
     </ng-template>
   `,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes the `readonly` and `tabIndex` of the inputs of `type="number"` for the material theme.

**What is the current behavior? (You can also link to an open issue here)**

Currently these have not been applied


**What is the new behavior (if this is a feature change)?**

nope, bugfix

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Other information**:

Related: https://github.com/ngx-formly/ngx-formly/pull/1372
