### PR TITLE
docs: add an example for material suffix and prefix

### DIFF
--- a/demo/src/app/examples/examples.component.ts
+++ b/demo/src/app/examples/examples.component.ts
@@ -70,6 +70,7 @@ export class ExamplesComponent {
       { href: './other/observable-select', text: 'Bind Observable to Select' },
       { href: './other/advanced-layout-flex', text: 'Advanced Layout (Flex)' },
       { href: './other/nested-formly-forms', text: 'Nested Forms (fieldGroup wrapper)' },
+      { href: './other/material-prefix-suffix', text: 'Material Field Prefix/Suffix' },
       { href: './other/hide-fields-with-animations', text: 'Hide Fields with `@angular/animations`' },
       { href: './other/button', text: 'Button Type' },
       { href: './other/json-powered', text: 'JSON powered' },

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -70,6 +70,7 @@ import { ExamplesComponent } from './examples.component';
           { path: 'observable-select', loadChildren: './other/observable-select/config.module#ConfigModule' },
           { path: 'advanced-layout-flex', loadChildren: './other/advanced-layout-flex/config.module#ConfigModule' },
           { path: 'nested-formly-forms', loadChildren: './other/nested-formly-forms/config.module#ConfigModule' },
+          { path: 'material-prefix-suffix', loadChildren: './other/material-prefix-suffix/config.module#ConfigModule' },
           { path: 'hide-fields-with-animations', loadChildren: './other/hide-fields-with-animations/config.module#ConfigModule' },
           { path: 'button', loadChildren: './other/button/config.module#ConfigModule' },
           { path: 'json-powered', loadChildren: './other/json-powered/config.module#ConfigModule' },

--- a/demo/src/app/examples/other/material-prefix-suffix/addons.extension.ts
+++ b/demo/src/app/examples/other/material-prefix-suffix/addons.extension.ts
@@ -1,0 +1,11 @@
+import { FormlyFieldConfig } from '@ngx-formly/core';
+
+export function addonsExtension(field: FormlyFieldConfig) {
+  if (!field.templateOptions || (field.wrappers && field.wrappers.indexOf('addons') !== -1)) {
+    return;
+  }
+
+  if (field.templateOptions.addonLeft || field.templateOptions.addonRight) {
+    field.wrappers = [...(field.wrappers || []), 'addons'];
+  }
+}

--- a/demo/src/app/examples/other/material-prefix-suffix/addons.wrapper.ts
+++ b/demo/src/app/examples/other/material-prefix-suffix/addons.wrapper.ts
@@ -1,0 +1,58 @@
+import { Component, TemplateRef, ViewChild, ViewContainerRef, AfterViewInit } from '@angular/core';
+import { FieldWrapper } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-wrapper-addons',
+  template: `
+  <ng-template #matPrefix>
+    <span
+      *ngIf="to.addonLeft"
+      [ngStyle]="{cursor: to.addonLeft.onClick ? 'pointer' : 'inherit'}"
+      (click)="addonLeftClick($event)"
+    >
+      <i *ngIf="to.addonLeft.class" [ngClass]="to.addonLeft.class"></i>&nbsp;
+      <span *ngIf="to.addonLeft.text">{{ to.addonLeft.text }}</span>&nbsp;
+    </span>
+  </ng-template>
+
+  <ng-container #fieldComponent></ng-container>
+
+  <ng-template #matSuffix>
+    <span
+      *ngIf="to.addonRight"
+      [ngStyle]="{cursor: to.addonRight.onClick ? 'pointer' : 'inherit'}"
+      (click)="addonRightClick($event)"
+    >
+      &nbsp;<i *ngIf="to.addonRight.class" [ngClass]="to.addonRight.class"></i>
+      &nbsp;<span *ngIf="to.addonRight.text">{{ to.addonRight.text }}</span>
+    </span>
+  </ng-template>
+  `,
+})
+export class FormlyWrapperAddons extends FieldWrapper implements AfterViewInit {
+  @ViewChild('fieldComponent', {read: ViewContainerRef}) fieldComponent!: ViewContainerRef;
+  @ViewChild('matPrefix') matPrefix: TemplateRef<any>;
+  @ViewChild('matSuffix') matSuffix: TemplateRef<any>;
+
+  ngAfterViewInit() {
+    if (this.matPrefix) {
+      Promise.resolve().then(() => this.to.prefix = this.matPrefix);
+    }
+
+    if (this.matSuffix) {
+      Promise.resolve().then(() => this.to.suffix = this.matSuffix);
+    }
+  }
+
+  addonRightClick($event: any) {
+    if (this.to.addonRight.onClick) {
+      this.to.addonRight.onClick(this.to, this, $event);
+    }
+  }
+
+  addonLeftClick($event: any) {
+    if (this.to.addonLeft.onClick) {
+      this.to.addonLeft.onClick(this.to, this, $event);
+    }
+  }
+}

--- a/demo/src/app/examples/other/material-prefix-suffix/app.component.html
+++ b/demo/src/app/examples/other/material-prefix-suffix/app.component.html
@@ -1,0 +1,4 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form">
+  </formly-form>
+</form>

--- a/demo/src/app/examples/other/material-prefix-suffix/app.component.ts
+++ b/demo/src/app/examples/other/material-prefix-suffix/app.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'input',
+      type: 'input',
+      templateOptions: {
+        label: 'Firstname',
+        addonLeft: {
+          class: 'fa fa-dashboard',
+        },
+        addonRight: {
+          text: '$',
+        },
+      },
+    },
+  ];
+}

--- a/demo/src/app/examples/other/material-prefix-suffix/app.module.ts
+++ b/demo/src/app/examples/other/material-prefix-suffix/app.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyMaterialModule } from '@ngx-formly/material';
+
+import { AppComponent } from './app.component';
+import { FormlyWrapperAddons } from './addons.wrapper';
+import { addonsExtension } from './addons.extension';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormlyMaterialModule,
+    FormlyModule.forRoot({
+      wrappers: [
+        { name: 'addons', component: FormlyWrapperAddons },
+      ],
+      extensions: [
+        { name: 'addons', extension: { onPopulate: addonsExtension } },
+      ],
+    }),
+  ],
+  declarations: [
+    AppComponent,
+    FormlyWrapperAddons,
+  ],
+})
+export class AppModule { }

--- a/demo/src/app/examples/other/material-prefix-suffix/config.module.ts
+++ b/demo/src/app/examples/other/material-prefix-suffix/config.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [{
+            title: 'Material Prefix and Suffix',
+            description: `
+              This demonstrates adding a material suffix and prefix for material form fields.
+            `,
+            component: AppComponent,
+            files: [
+              { file: 'app.component.html', content: require('!!prismjs-loader?lang=html!./app.component.html'), filecontent: require('!!raw-loader?lang=html!./app.component.html') },
+              { file: 'app.component.ts', content: require('!!prismjs-loader?lang=typescript!./app.component.ts'), filecontent: require('!!raw-loader?lang=typescript!./app.component.ts') },
+              { file: 'addons.wrapper.ts', content: require('!!prismjs-loader?lang=typescript!./addons.wrapper.ts'), filecontent: require('!!raw-loader?lang=typescript!./addons.wrapper.ts') },
+              { file: 'addons.extension.ts', content: require('!!prismjs-loader?lang=typescript!./addons.extension.ts'), filecontent: require('!!raw-loader?lang=typescript!./addons.extension.ts') },
+              { file: 'app.module.ts', content: require('!!prismjs-loader?lang=typescript!./app.module.ts'), filecontent: require('!!raw-loader?lang=typescript!./app.module.ts') },
+            ],
+          }],
+        },
+      },
+    ]),
+  ],
+  entryComponents: [AppComponent],
+})
+export class ConfigModule { }


### PR DESCRIPTION
Add an example for using angular material suffix and prefix.
Fixes #1369 

![image](https://user-images.githubusercontent.com/1163421/51837603-86d20000-230c-11e9-81f9-ba4f1380b5f9.png)


