### PR TITLE
feat(core): deep merge widget prop & add map callback

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -239,6 +239,76 @@ describe('Service: FormlyJsonschema', () => {
         expect(config3.templateOptions.valueProp('test')).toBe('test');
       });
 
+      describe('widget formlyConfig options merging', () => {
+
+        it('should merge a formlyConfig object specified in the widget property into the formly config', () => {
+          const schema: JSONSchema7 = JSON.parse(`{
+            "type": "integer",
+            "widget": {
+              "formlyConfig": {
+                "templateOptions": {
+                  "label": "Age"
+                }
+              }
+            }
+          }`);
+
+          const config = formlyJsonschema.toFieldConfig(schema);
+
+          expect(config.templateOptions.label).toBe('Age');
+        });
+
+        it('should override properties that have already been set', () => {
+          const schema: JSONSchema7 = JSON.parse(`{
+            "type": "integer",
+            "title": "Person Age",
+            "widget": {
+              "formlyConfig": {
+                "templateOptions": {
+                  "label": "Age"
+                }
+              }
+            }
+          }`);
+
+          const config = formlyJsonschema.toFieldConfig(schema);
+
+          expect(config.templateOptions.label).toBe('Age');
+        });
+
+      });
+
+      describe('FormlyJsonSchemaOptions map function', () => {
+
+        it('should allow to pass in a "map" function to further customize the mapping', () => {
+          const schema: JSONSchema7 = JSON.parse(`{
+            "type": "integer",
+            "title": "Person Age",
+            "widget": {
+              "formlyConfig": {
+                "templateOptions": {
+                  "label": "Age"
+                }
+              }
+            }
+          }`);
+
+          const config = formlyJsonschema.toFieldConfig(schema, {
+            map: (field: FormlyFieldConfig, mapSource: JSONSchema7) => {
+              // not a very real-world mapping scenario 😊
+              if (field.type === 'integer') {
+                field.templateOptions.label = 'my custom label';
+              }
+
+              return field;
+            },
+          });
+
+          expect(config.templateOptions.label).toBe('my custom label');
+        });
+
+      });
+
       // TODO: add support for adding custom labels to enum values using oneOf/const
       // https://github.com/json-schema-org/json-schema-spec/issues/57#issuecomment-247861695
       // it('should support enum as oneOf structure', () => {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -1,15 +1,25 @@
 import { Injectable } from '@angular/core';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { JSONSchema7, JSONSchema7TypeName } from 'json-schema';
+import { ɵreverseDeepMerge as reverseDeepMerge } from '@ngx-formly/core';
+
+export interface FormlyJsonschemaOptions {
+  /**
+   * allows to intercept the mapping, taking the already mapped
+   * formly field and the original JSONSchema source from which it
+   * was mapped.
+   */
+  map?: (mappedField: FormlyFieldConfig, mapSource: JSONSchema7) => FormlyFieldConfig;
+}
 
 @Injectable({ providedIn: 'root' })
 export class FormlyJsonschema {
-  toFieldConfig(jsonSchema: JSONSchema7): FormlyFieldConfig {
-    return this._toFieldConfig(jsonSchema);
+  toFieldConfig(jsonSchema: JSONSchema7, options?: FormlyJsonschemaOptions): FormlyFieldConfig {
+    return this._toFieldConfig(jsonSchema, null, options);
   }
 
-  _toFieldConfig(jsonSchema: JSONSchema7, key?: string): FormlyFieldConfig {
-    const field: FormlyFieldConfig = {
+  _toFieldConfig(jsonSchema: JSONSchema7, key?: string, options?: FormlyJsonschemaOptions): FormlyFieldConfig {
+    let field: FormlyFieldConfig = {
       ...(key ? { key } : {}),
       type: jsonSchema.type as JSONSchema7TypeName,
       defaultValue: jsonSchema.default,
@@ -39,7 +49,7 @@ export class FormlyJsonschema {
       case 'object': {
         field.fieldGroup = [];
         Object.keys(jsonSchema.properties).forEach(p => {
-          const child = this._toFieldConfig(<JSONSchema7> jsonSchema.properties[p], p);
+          const child = this._toFieldConfig(<JSONSchema7> jsonSchema.properties[p], p, options);
           if (Array.isArray(jsonSchema.required) && jsonSchema.required.indexOf(p) !== -1) {
             child.templateOptions.required = true;
           }
@@ -49,13 +59,13 @@ export class FormlyJsonschema {
       }
       case 'array': {
         if (!Array.isArray(jsonSchema.items)) {
-          field.fieldArray = this._toFieldConfig(jsonSchema.items as JSONSchema7);
+          field.fieldArray = this._toFieldConfig(jsonSchema.items as JSONSchema7, key, options);
         } else {
           field['_fieldArray'] = [];
           field.fieldGroup = [];
-          jsonSchema.items.forEach(item => field['_fieldArray'].push(this._toFieldConfig(<JSONSchema7> item)));
+          jsonSchema.items.forEach(item => field['_fieldArray'].push(this._toFieldConfig(<JSONSchema7> item, key, options)));
           if (jsonSchema.additionalItems) {
-            field['_additionalFieldArray'] = this._toFieldConfig(<JSONSchema7> jsonSchema.additionalItems);
+            field['_additionalFieldArray'] = this._toFieldConfig(<JSONSchema7> jsonSchema.additionalItems, key, options);
           }
 
           Object.defineProperty(field, 'fieldArray', {
@@ -68,6 +78,18 @@ export class FormlyJsonschema {
         }
         break;
       }
+    }
+
+    // map in possible formlyConfig options from the widget property
+    if (jsonSchema['widget'] && jsonSchema['widget'].formlyConfig) {
+      const widgetConfig = jsonSchema['widget'].formlyConfig;
+      field = reverseDeepMerge(widgetConfig, field);
+    }
+
+    // if there is a map function passed in, use it to allow the user to
+    // further customize how fields are being mapped
+    if (options && options.map) {
+      field = options.map(field, jsonSchema);
     }
 
     return field;

--- a/src/core/src/lib/core.ts
+++ b/src/core/src/lib/core.ts
@@ -9,3 +9,4 @@ export { FieldArrayType } from './templates/field-array.type';
 export { FieldWrapper } from './templates/field.wrapper';
 export { FormlyModule } from './core.module';
 export { defineHiddenProp as ɵdefineHiddenProp } from './utils';
+export { reverseDeepMerge as ɵreverseDeepMerge } from './utils';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

As discussed in #1459 this adds 2 things

**deep merge of `widget.formlyConfig` property using the already existing algorithm

```
...
// map in possible formlyConfig options from the widget property
if (jsonSchema['widget'] && jsonSchema['widget'].formlyConfig) {
  const widgetConfig = jsonSchema['widget'].formlyConfig;
  field = reverseDeepMerge(field, widgetConfig);
}
...
```

The second thing is **the ability to pass in a `FormlyJsonschemaOptions` with a `map` function callback that allows to further customize the mapping of the formly field from the JSONSchema source.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Other information**:

@aitboudad There is an open question here, namely whether the "deep merge" with the `widget.formlyConfig` object should overwrite existing mappings or not. Right now I'm doing the mappings (you already had in the `FormlyJsonschema` and then I apply the "deep merge" by calling the `reverseDeepMerge`. I've seen that function doesn't overwrite, so I left this behavior for now.
Still thinking whether that's right 🤔.

Because that also means that something like

```
{
   type: 'integer',
   ...,
   widget: {
      formlyConfig: {
         type: 'select',
         templateOptions: { ... }
      }
   }
}
```

wouldn't work. The `type` is already set by the JSONSchema so the `formlyConfig` doesn't overwrite it. What do you think?