### PR TITLE
fix(material): in number input with value 0 label doesn't float. Closes #1029

### DIFF
--- a/src/ui-material/src/types/field.ts
+++ b/src/ui-material/src/types/field.ts
@@ -64,7 +64,7 @@ export abstract class FieldType extends CoreFieldType implements OnInit, AfterVi
   get shouldPlaceholderFloat() { return !!this.to.placeholder; }
   get value() { return this.formControl.value; }
   get ngControl() { return this.formControl as any; }
-  get empty() { return !this.formControl.value; }
+  get empty() { return this.formControl.value === null || typeof this.formControl.value === "undefined"; }
   get shouldLabelFloat() { return this.focused || !this.empty; }
   get formField(): MatFormField { return (<any>this.field)['__formField__']; }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
It's a bugfix to avoid that inputs of type number, and also mat-select where mat-options have a [value] that is a number, have their label NOT floating when the bound value is 0, thus resulting in the getter property "empty" to return true.
See #1029 

**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
Before:
![image](https://user-images.githubusercontent.com/4141889/56196611-73931e80-6037-11e9-95dd-33c310a80a52.png)

After:
![image](https://user-images.githubusercontent.com/4141889/56196451-244cee00-6037-11e9-9748-b79b67e54890.png)

The same code for the  empty getter is in form-field.wrapper.ts but changing only that doesn't seem to have any effect. Maybe you will know whether to edit that piece of code too.