### PR TITLE
feat(core): add field arg to hideExpression and expressionProperties

### DIFF
--- a/demo/src/app/guides/expression-properties.md
+++ b/demo/src/app/guides/expression-properties.md
@@ -34,7 +34,7 @@ Example with function value:
     placeholder: ''
   },
   expressionProperties: {
-    'templateOptions.disabled':(model: any, formState: any) => {
+    'templateOptions.disabled': (model: any, formState: any, field: FormlyFieldConfig) => {
       // access to the main model can be through `this.model` or `formState` or `model
       return !formState.mainModel.text
     },
@@ -84,7 +84,7 @@ You can see an example [here](https://stackblitz.com/edit/angular-formly-ndfcmz?
     label: 'City',
     placeholder: 'set to 123'
   },
-  hideExpression: (model: any, formState: any) => {
+  hideExpression: (model: any, formState: any, field: FormlyFieldConfig) => {
     // access to the main model can be through `this.model` or `formState` or `model
     if (formState.mainModel && formState.mainModel.city) {
       return formState.mainModel.city !== "123"

--- a/src/core/src/lib/components/formly.field.config.ts
+++ b/src/core/src/lib/components/formly.field.config.ts
@@ -97,12 +97,12 @@ export interface FormlyFieldConfig {
   /**
    * Conditionally hiding Field based on values from other Fields
    */
-  hideExpression?: boolean | string | ((model: any, formState: any) => boolean);
+  hideExpression?: boolean | string | ((model: any, formState: any, field: FormlyFieldConfig) => boolean);
 
   /**
    * An object where the key is a property to be set on the main field config and the value is an expression used to assign that property.
    */
-  expressionProperties?: { [property: string]: string | ((model: any, formState: any) => any) | Observable<any> };
+  expressionProperties?: { [property: string]: string | ((model: any, formState: any, field: FormlyFieldConfig) => any) | Observable<any> };
 
   /**
    * This is the [FormControl](https://angular.io/api/forms/FormControl) for the field.

--- a/src/core/src/lib/components/formly.form.spec.ts
+++ b/src/core/src/lib/components/formly.form.spec.ts
@@ -360,7 +360,7 @@ describe('FormlyForm Component', () => {
           placeholder: 'Title',
         },
       };
-      testComponentInputs = { fields: [field], model: { address: { city: '' } } };
+      testComponentInputs = { fields: [field], options: { formState: { blah: 1 } }, model: { address: { city: '' } } };
     });
 
     it('should hide field using a boolean value', () => {
@@ -390,6 +390,18 @@ describe('FormlyForm Component', () => {
       field.hideExpression = () => false;
       fixture.detectChanges();
       expect(getFormlyFieldElement(fixture.nativeElement).getAttribute('style')).toEqual('');
+    });
+
+    it('should provide model, formState and field', () => {
+      const spy = jasmine.createSpy('hideExpression spy');
+      field.hideExpression = spy;
+
+      const fixture = createTestComponent('<formly-form [fields]="fields" [options]="options" [model]="model"></formly-form>');
+      fixture.detectChanges();
+      const args = spy.calls.mostRecent().args;
+      expect(args[0]).toEqual(testComponentInputs.model);
+      expect(args[1]).toEqual(testComponentInputs.options.formState);
+      expect(args[2]).toEqual(field);
     });
 
     it('should apply model changes when form is enabled', () => {

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -89,11 +89,11 @@ export class FieldExpressionExtension implements FormlyExtension {
   private _evalExpression(expression, parentExpression?) {
     expression = expression || (() => false);
     if (typeof expression === 'string') {
-      expression = evalStringExpression(expression, ['model', 'formState']);
+      expression = evalStringExpression(expression, ['model', 'formState', 'field']);
     }
 
     return parentExpression
-      ? (model: any, formState: any) => parentExpression() || expression(model, formState)
+      ? (model: any, formState: any, field: FormlyFieldConfig) => parentExpression() || expression(model, formState, field)
       : expression;
   }
 
@@ -123,7 +123,7 @@ export class FieldExpressionExtension implements FormlyExtension {
     const validators = FORMLY_VALIDATORS.map(v => `templateOptions.${v}`);
 
     for (const key in expressionProperties) {
-      let expressionValue = evalExpression(expressionProperties[key].expression, { field }, [field.model, field.options.formState]);
+      let expressionValue = evalExpression(expressionProperties[key].expression, { field }, [field.model, field.options.formState, field]);
       if (key === 'templateOptions.disabled') {
         expressionValue = !!expressionValue;
       }
@@ -172,7 +172,7 @@ export class FieldExpressionExtension implements FormlyExtension {
     const hideExpressionResult: boolean = !!evalExpression(
       field.hideExpression,
       { field },
-      [field.model, field.options.formState],
+      [field.model, field.options.formState, field],
     );
     let markForCheck = false;
     if (hideExpressionResult !== field.hide || ignoreCache) {


### PR DESCRIPTION
Add field argument to hideExpression and expressionProperties

fix #704

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
