### PR TITLE
feat(material): add select all option to multiselect

### DIFF
--- a/demo/src/app/ui/common/select/app.component.ts
+++ b/demo/src/app/ui/common/select/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 
 @Component({
   selector: 'formly-app-example',
@@ -19,6 +19,24 @@ export class AppComponent {
         placeholder: 'Placeholder',
         description: 'Description',
         required: true,
+        options: [
+          { value: 1, label: 'Option 1'  },
+          { value: 2, label: 'Option 2'  },
+          { value: 3, label: 'Option 3'  },
+          { value: 4, label: 'Option 4'  },
+        ],
+      },
+    },
+    {
+      key: 'select_multi',
+      type: 'select',
+      templateOptions: {
+        label: 'Select Multiple',
+        placeholder: 'Placeholder',
+        description: 'Description',
+        required: true,
+        multiple: true,
+        selectAllOption: 'Select All',
         options: [
           { value: 1, label: 'Option 1'  },
           { value: 2, label: 'Option 2'  },

--- a/src/material/select/src/select.module.ts
+++ b/src/material/select/src/select.module.ts
@@ -8,6 +8,7 @@ import { FormlyMatFormFieldModule } from '@ngx-formly/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 
 import { FormlyFieldSelect } from './select.type';
+import { MatPseudoCheckboxModule } from '@angular/material/core';
 
 @NgModule({
   declarations: [FormlyFieldSelect],
@@ -15,6 +16,7 @@ import { FormlyFieldSelect } from './select.type';
     CommonModule,
     ReactiveFormsModule,
     MatSelectModule,
+    MatPseudoCheckboxModule,
 
     FormlyMatFormFieldModule,
     FormlySelectModule,

--- a/src/material/select/src/select.spec.ts
+++ b/src/material/select/src/select.spec.ts
@@ -10,6 +10,7 @@ import { FormlyModule, FormlyForm } from '@ngx-formly/core';
 import { FormlySelectModule } from '@ngx-formly/core/select';
 import { FormlyFieldSelect } from './select.type';
 import { of as observableOf } from 'rxjs';
+import { MatPseudoCheckboxModule } from '@angular/material/core';
 
 const createTestComponent = (html: string) =>
   createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -23,6 +24,7 @@ describe('ui-material: Formly Field Select Component', () => {
       imports: [
         NoopAnimationsModule,
         MatSelectModule,
+        MatPseudoCheckboxModule,
         ReactiveFormsModule,
         FormlySelectModule,
         FormlyModule.forRoot({
@@ -98,6 +100,91 @@ describe('ui-material: Formly Field Select Component', () => {
 
   });
 
+  describe('multi select', () => {
+
+    beforeEach(() => {
+      testComponentInputs = {
+        form: new FormGroup({}),
+        options: {},
+        model: {},
+      };
+
+      testComponentInputs.fields = [{
+        key: 'sportId',
+        type: 'select',
+        templateOptions: {
+          multiple: true,
+          selectAllOption: 'Select All',
+          options: [
+            { id: '1', name: 'Soccer' },
+            { id: '2', name: 'Basketball' },
+            { id: '3', name: 'Martial Arts' },
+          ],
+          valueProp: 'id',
+          labelProp: 'name',
+        },
+      }];
+    });
+
+    it('should have a "Select All" option if configured', () => {
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+
+      trigger.click();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(1 + 3);
+    });
+
+    it('should select all options if clicking the "Select All" option', () => {
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+
+      trigger.click();
+      fixture.detectChanges();
+
+      const selectAllOption = fixture.debugElement.queryAll(By.css('mat-option'))[0].nativeElement;
+      selectAllOption.click();
+      fixture.detectChanges();
+
+      expect(testComponentInputs.form.get('sportId').value.length).toEqual(3);
+
+      // clicking again should deselect all
+      selectAllOption.click();
+      fixture.detectChanges();
+
+      expect(testComponentInputs.form.get('sportId').value.length).toEqual(0);
+    });
+
+    it('should use the selectAllOption prop as label for the option entry', () => {
+      testComponentInputs.fields = [{
+        key: 'sportId',
+        type: 'select',
+        templateOptions: {
+          multiple: true,
+          selectAllOption: 'Click me!!',
+          options: [
+            { id: '1', name: 'Soccer' },
+            { id: '2', name: 'Basketball' },
+            { id: '3', name: 'Martial Arts' },
+          ],
+          valueProp: 'id',
+          labelProp: 'name',
+        },
+      }];
+
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+
+      trigger.click();
+      fixture.detectChanges();
+
+      const selectAllOption = fixture.debugElement.queryAll(By.css('mat-option'))[0].nativeElement;
+      expect(selectAllOption.innerHTML).toContain('Click me!!');
+    });
+
+  });
+
 });
 
 @Component({ selector: 'formly-form-test', template: '', entryComponents: [] })
@@ -105,7 +192,7 @@ class TestComponent {
   @ViewChild(FormlyForm) formlyForm: FormlyForm;
 
   fields = testComponentInputs.fields;
-  form = testComponentInputs.form;
+  form: FormGroup = testComponentInputs.form;
   model = testComponentInputs.model || {};
   options = testComponentInputs.options;
 }

--- a/src/material/select/src/select.type.ts
+++ b/src/material/select/src/select.type.ts
@@ -5,6 +5,15 @@ import { FieldType } from '@ngx-formly/material/form-field';
 @Component({
   selector: 'formly-field-mat-select',
   template: `
+    <ng-template #selectAll>
+      <mat-option (click)="toggleSelectAll()">
+        <mat-pseudo-checkbox class="mat-option-pseudo-checkbox"
+          [state]="state">
+        </mat-pseudo-checkbox>
+        {{ to.selectAllOption }}
+      </mat-option>
+    </ng-template>
+
     <mat-select [id]="id"
       [formControl]="formControl"
       [formlyAttributes]="field"
@@ -17,6 +26,7 @@ import { FieldType } from '@ngx-formly/material/form-field';
       [aria-labelledby]="formField?._labelId"
       [disableOptionCentering]="to.disableOptionCentering"
       >
+      <ng-container *ngIf="to.multiple && to.selectAllOption" [ngTemplateOutlet]="selectAll"></ng-container>
       <ng-container *ngFor="let item of to.options | formlySelectOptions:field | async">
         <mat-optgroup *ngIf="item.group" [label]="item.label">
           <mat-option *ngFor="let child of item.group" [value]="child.value" [disabled]="child.disabled">
@@ -30,9 +40,29 @@ import { FieldType } from '@ngx-formly/material/form-field';
 })
 export class FormlyFieldSelect extends FieldType {
   @ViewChild(MatSelect) formFieldControl!: MatSelect;
+
   defaultOptions = {
     templateOptions: { options: [] },
   };
+
+  get value() { return this.formControl.value || []; }
+  get state() {
+    if (this.value.length > 0) {
+      return this.value.length !== this.formFieldControl.options.length
+        ? 'indeterminate'
+        : 'checked';
+    }
+
+    return '';
+  }
+
+  toggleSelectAll() {
+    this.formControl.setValue(
+      this.value.length !== this.formFieldControl.options.length
+        ? this.formFieldControl.options.map(x => x.value)
+        : [],
+    );
+  }
 
   change($event: MatSelectChange) {
     if (this.to.change) {


### PR DESCRIPTION
This PR implements the new feature described in #1516 .

- [x] add `selectAllOption` configuration
- [x] allow passing boolean or string value to `selectAllOption`. String will be used as label if provided
- [x] implement select all / deselect all
- [x] add some automated tests