### PR TITLE
Adding Material prefix option for the datepicker icon.

### DIFF
--- a/src/material/datepicker/src/datepicker.type.ts
+++ b/src/material/datepicker/src/datepicker.type.ts
@@ -18,10 +18,10 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
       [placeholder]="to.placeholder"
       [tabindex]="to.tabindex || 0"
       [readonly]="to.readonly">
-    <ng-template #matPrefix *ngIf="to.datepickerOptions.prefixIcon">
+    <ng-template #matPrefix *ngIf="to.datepickerTogglePosition ==='prefix'">
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>
-    <ng-template #matSuffix *ngIf="!to.datepickerOptions.prefixIcon">
+    <ng-template #matSuffix *ngIf="to.datepickerTogglePosition ==='suffix'">
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>
     <mat-datepicker #picker

--- a/src/material/datepicker/src/datepicker.type.ts
+++ b/src/material/datepicker/src/datepicker.type.ts
@@ -24,7 +24,6 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
     <ng-template #matSuffix *ngIf="!to.datepickerOptions.prefixIcon">
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker #picker
       [color]="to.color"
       [touchUi]="to.datepickerOptions.touchUi"

--- a/src/material/datepicker/src/datepicker.type.ts
+++ b/src/material/datepicker/src/datepicker.type.ts
@@ -18,9 +18,13 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
       [placeholder]="to.placeholder"
       [tabindex]="to.tabindex || 0"
       [readonly]="to.readonly">
-    <ng-template #matSuffix>
+    <ng-template #matPrefix *ngIf="to.datepickerOptions.prefixIcon">
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>
+    <ng-template #matSuffix *ngIf="!to.datepickerOptions.prefixIcon">
+      <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
+    </ng-template>
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker #picker
       [color]="to.color"
       [touchUi]="to.datepickerOptions.touchUi"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This change allows the datepicker icon to be used as a prefix instead of a suffix icon by using to.datepickerOptions.prefixIcon.


**What is the current behavior? (You can also link to an open issue here)**
The icon is always a suffix icon. Moving it to the left requires brittle css.


**What is the new behavior (if this is a feature change)?**
The icon can now be left/right aligned without css hacks.