### PR TITLE
feat(material-datepicker-toggle): add positioning support

### DIFF
--- a/src/material/datepicker/src/datepicker.type.ts
+++ b/src/material/datepicker/src/datepicker.type.ts
@@ -18,7 +18,10 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
       [placeholder]="to.placeholder"
       [tabindex]="to.tabindex || 0"
       [readonly]="to.readonly">
-    <ng-template #matSuffix>
+    <ng-template #matPrefix *ngIf="to.datepickerTogglePosition ==='prefix'">
+      <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
+    </ng-template>
+    <ng-template #matSuffix *ngIf="to.datepickerTogglePosition ==='suffix'">
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>
     <mat-datepicker #picker


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Add support for datepickerTogglePosition which support prefix/suffix. By default, the icon is missing.

What is the current behavior? (You can also link to an open issue here)
The toggle currently only supports suffix.

What is the new behavior (if this is a feature change)?
Support for prefix/suffix/none.