### PR TITLE
feat(material): adds datepicker toggle positioning support

### DIFF
--- a/src/material/datepicker/src/datepicker.type.ts
+++ b/src/material/datepicker/src/datepicker.type.ts
@@ -1,4 +1,5 @@
-import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, ViewChild, AfterViewInit, TemplateRef } from '@angular/core';
+import { ɵdefineHiddenProp as defineHiddenProp } from '@ngx-formly/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatDatepickerInput } from '@angular/material/datepicker';
@@ -18,7 +19,7 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
       [placeholder]="to.placeholder"
       [tabindex]="to.tabindex || 0"
       [readonly]="to.readonly">
-    <ng-template #matSuffix>
+    <ng-template #datepickerToggle>
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>
     <mat-datepicker #picker
@@ -32,11 +33,13 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
 export class FormlyDatepickerTypeComponent extends FieldType implements AfterViewInit {
   @ViewChild(MatInput) formFieldControl!: MatInput;
   @ViewChild(MatDatepickerInput) datepickerInput!: MatDatepickerInput<any>;
+  @ViewChild('datepickerToggle') datepickerToggle!: TemplateRef<any>;
 
   defaultOptions = {
     templateOptions: {
       datepickerOptions: {
         startView: 'month',
+        datepickerTogglePosition: 'suffix',
       },
     },
   };
@@ -45,5 +48,9 @@ export class FormlyDatepickerTypeComponent extends FieldType implements AfterVie
     super.ngAfterViewInit();
     // temporary fix for https://github.com/angular/material2/issues/6728
     (<any> this.datepickerInput)._formField = this.formField;
+
+    setTimeout(() => {
+      defineHiddenProp(this.field, '_mat' + this.to.datepickerOptions.datepickerTogglePosition, this.datepickerToggle);
+    });
   }
 }

--- a/src/material/form-field/src/field.type.ts
+++ b/src/material/form-field/src/field.type.ts
@@ -30,8 +30,8 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
   ngAfterViewInit() {
     if (this.matPrefix || this.matSuffix) {
       setTimeout(() => {
-        defineHiddenProp(this.field, '_matPrefix', this.matPrefix);
-        defineHiddenProp(this.field, '_matSuffix', this.matSuffix);
+        defineHiddenProp(this.field, '_matprefix', this.matPrefix);
+        defineHiddenProp(this.field, '_matsuffix', this.matSuffix);
         (<any> this.options)._markForCheck(this.field);
       });
     }

--- a/src/material/form-field/src/form-field.wrapper.ts
+++ b/src/material/form-field/src/form-field.wrapper.ts
@@ -7,8 +7,8 @@ import { Subject } from 'rxjs';
 import { FieldType } from './field.type';
 
 interface MatFormlyFieldConfig extends FormlyFieldConfig {
-  _matPrefix: TemplateRef<any>;
-  _matSuffix: TemplateRef<any>;
+  _matprefix: TemplateRef<any>;
+  _matsuffix: TemplateRef<any>;
   __formField__: FormlyWrapperFormField;
   _componentFactory: any;
 }
@@ -30,11 +30,11 @@ interface MatFormlyFieldConfig extends FormlyFieldConfig {
       </mat-label>
 
       <ng-container matPrefix>
-        <ng-container *ngTemplateOutlet="to.prefix ? to.prefix : formlyField._matPrefix"></ng-container>
+        <ng-container *ngTemplateOutlet="to.prefix ? to.prefix : formlyField._matprefix"></ng-container>
       </ng-container>
 
       <ng-container matSuffix>
-        <ng-container *ngTemplateOutlet="to.suffix ? to.suffix : formlyField._matSuffix"></ng-container>
+        <ng-container *ngTemplateOutlet="to.suffix ? to.suffix : formlyField._matsuffix"></ng-container>
       </ng-container>
 
       <!-- fix https://github.com/angular/material2/issues/7737 by setting id to null  -->


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Add support for datepickerTogglePosition which support prefix/suffix. By default, the icon is missing.

**What is the current behavior? (You can also link to an open issue here)**
The toggle currently only supports suffix.

**What is the new behavior (if this is a feature change)?**
Support for prefix/suffix/none.