### PR TITLE
feat(json-schema): adds allOf support

### DIFF
--- a/demo/src/app/examples/advanced/json-schema/app.component.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.component.ts
@@ -23,6 +23,7 @@ export class AppComponent {
     'numbers',
     'references',
     'schema_dependencies',
+    'allOf',
   ];
 
   constructor(

--- a/demo/src/app/examples/advanced/json-schema/assets/allOf_json
+++ b/demo/src/app/examples/advanced/json-schema/assets/allOf_json
@@ -1,0 +1,58 @@
+{
+  "schema": {
+    "title": "Extending",
+    "definitions": {
+      "address": {
+        "type": "object",
+        "properties": {
+          "street_address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "city": {
+            "title": "City",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "street_address",
+          "city",
+          "state"
+        ]
+      }
+    },
+    "type": "object",
+    "properties": {
+      "billing_address": {
+        "title": "Billing Address",
+        "$ref": "#/definitions/address"
+      },
+      "shipping_address": {
+        "allOf": [
+          {
+            "title": "Shipping Address",
+            "$ref": "#/definitions/address"
+          },
+          {
+            "properties": {
+              "type": {
+                "title": "Type",
+                "enum": [
+                  "residential",
+                  "business"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/demo/src/app/examples/advanced/json-schema/config.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/config.module.ts
@@ -29,6 +29,7 @@ import { AppComponent } from './app.component';
               { file: 'assets/json-schema/numbers.json', content: require('!!highlight-loader?raw=true&lang=typescript!./assets/numbers_json'), filecontent: require('!!raw-loader!./assets/numbers_json') },
               { file: 'assets/json-schema/references.json', content: require('!!highlight-loader?raw=true&lang=typescript!./assets/references_json'), filecontent: require('!!raw-loader!./assets/references_json') },
               { file: 'assets/json-schema/schema_dependencies.json', content: require('!!highlight-loader?raw=true&lang=typescript!./assets/schema_dependencies_json'), filecontent: require('!!raw-loader!./assets/schema_dependencies_json') },
+              { file: 'assets/json-schema/allOf.json', content: require('!!highlight-loader?raw=true&lang=typescript!./assets/allOf_json'), filecontent: require('!!raw-loader!./assets/allOf_json') },
             ],
           }],
         },

--- a/demo/src/assets/json-schema/allOf.json
+++ b/demo/src/assets/json-schema/allOf.json
@@ -1,0 +1,58 @@
+{
+  "schema": {
+    "title": "Extending",
+    "definitions": {
+      "address": {
+        "type": "object",
+        "properties": {
+          "street_address": {
+            "title": "Address",
+            "type": "string"
+          },
+          "city": {
+            "title": "City",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "street_address",
+          "city",
+          "state"
+        ]
+      }
+    },
+    "type": "object",
+    "properties": {
+      "billing_address": {
+        "title": "Billing Address",
+        "$ref": "#/definitions/address"
+      },
+      "shipping_address": {
+        "allOf": [
+          {
+            "title": "Shipping Address",
+            "$ref": "#/definitions/address"
+          },
+          {
+            "properties": {
+              "type": {
+                "title": "Housing type",
+                "enum": [
+                  "Residential",
+                  "Business"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -546,6 +546,40 @@ describe('Service: FormlyJsonschema', () => {
 
       });
     });
+
+    // https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.7
+    describe('Schema allOf support', () => {
+      it('should merge allOf array into single object ', () => {
+        const schema: JSONSchema7 = {
+          'definitions': {
+            'address': {
+              'type': 'object',
+              'properties': {
+                'street_address': { 'type': 'string' },
+                'city':           { 'type': 'string' },
+                'state':          { 'type': 'string' },
+              },
+              'required': ['street_address', 'city', 'state'],
+            },
+          },
+          'type': 'object',
+          'properties': {
+            'billing_address': {
+              allOf: [
+                {'$ref': '#/definitions/address'},
+                { 'properties': {
+                    'type': { 'enum': [ 'residential', 'business' ] },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        const config = formlyJsonschema.toFieldConfig(schema);
+        expect(config.fieldGroup[0].fieldGroup[0].key).toEqual('type');
+        expect(config.fieldGroup[0].fieldGroup[0].type).toEqual('enum');
+      });
+    })
     // TODO: discuss support of writeOnly. Note: this may not be needed.
     // TODO: discuss support of examples. By spec, default can be used in its place.
     // https://json-schema.org/latest/json-schema-validation.html#rfc.section.10

--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -579,7 +579,7 @@ describe('Service: FormlyJsonschema', () => {
         expect(config.fieldGroup[0].fieldGroup[0].key).toEqual('type');
         expect(config.fieldGroup[0].fieldGroup[0].type).toEqual('enum');
       });
-    })
+    });
     // TODO: discuss support of writeOnly. Note: this may not be needed.
     // TODO: discuss support of examples. By spec, default can be used in its place.
     // https://json-schema.org/latest/json-schema-validation.html#rfc.section.10

--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -579,6 +579,48 @@ describe('Service: FormlyJsonschema', () => {
         expect(config.fieldGroup[0].fieldGroup[0].key).toEqual('type');
         expect(config.fieldGroup[0].fieldGroup[0].type).toEqual('enum');
       });
+
+      it('should handle nested allOf  ', () => {
+        const schema: JSONSchema7 = {
+          'definitions': {
+            'baseAddress': {
+              'type': 'object',
+              'properties': {
+                'street_address': { 'type': 'string' },
+                'city':           { 'type': 'string' },
+                'state':          { 'type': 'string' },
+              },
+              'required': ['street_address', 'city', 'state'],
+            },
+            'mailingAddress': {
+              allOf: [
+                {'$ref': '#/definitions/baseAddress'},
+                { 'properties': {
+                    'country': { 'type': 'string' },
+                  },
+                },
+              ],
+            },
+          },
+          'type': 'object',
+          'properties': {
+            'billing_address': {
+              allOf: [
+                {'$ref': '#/definitions/mailingAddress'},
+                { 'properties': {
+                    'type': { 'enum': [ 'residential', 'business' ] },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        const config = formlyJsonschema.toFieldConfig(schema);
+        expect(config.fieldGroup[0].fieldGroup[0].key).toEqual('type');
+        expect(config.fieldGroup[0].fieldGroup[0].type).toEqual('enum');
+        expect(config.fieldGroup[0].fieldGroup[1].key).toEqual('country');
+        expect(config.fieldGroup[0].fieldGroup[1].type).toEqual('string');
+      });
     });
     // TODO: discuss support of writeOnly. Note: this may not be needed.
     // TODO: discuss support of examples. By spec, default can be used in its place.

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -149,15 +149,17 @@ export class FormlyJsonschema {
     if (!schema.allOf.length) {
       throw Error(`allOf array can not be empty ${schema.allOf}.`);
     }
-    return {
-      ...schema.allOf.reduce((prev: JSONSchema7, curr: JSONSchema7) => {
+    return schema.allOf.reduce((prev: JSONSchema7, curr: JSONSchema7) => {
         if (curr.$ref) {
-          return this.resolveDefinition(curr, options);
+          curr = this.resolveDefinition(curr, options);
+        }
+        if (curr.allOf) {
+          curr = this.resolveAllOf(curr, options);
         }
         return reverseDeepMerge(curr, prev);
-      }, {}),
-    };
+      }, {});
   }
+
   private resolveDefinition(schema: JSONSchema7, options: IOptions): JSONSchema7 {
     const [uri, pointer] = schema.$ref.split('#/');
     if (uri) {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -149,14 +149,13 @@ export class FormlyJsonschema {
     if (!schema.allOf.length) {
       throw Error(`allOf array can not be empty ${schema.allOf}.`);
     }
-    const combined = schema.allOf.reduce((prev: JSONSchema7, curr: JSONSchema7) => {
-      if (curr.$ref) {
-        return this.resolveDefinition(curr, options);
-      }
-      return reverseDeepMerge(curr, prev);
-    }, {});
     return {
-      ...combined,
+      ...schema.allOf.reduce((prev: JSONSchema7, curr: JSONSchema7) => {
+        if (curr.$ref) {
+          return this.resolveDefinition(curr, options);
+        }
+        return reverseDeepMerge(curr, prev);
+      }, {}),
     };
   }
   private resolveDefinition(schema: JSONSchema7, options: IOptions): JSONSchema7 {


### PR DESCRIPTION
re #1459

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
adds combine schema allOf support.


**What is the current behavior? (You can also link to an open issue here)**
none


**What is the new behavior (if this is a feature change)?**
merges allOf schema array objects into one


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
