### PR TITLE
fix(core): better cloning

### DIFF
--- a/src/core/src/lib/utils.spec.ts
+++ b/src/core/src/lib/utils.spec.ts
@@ -150,6 +150,34 @@ describe('clone', () => {
     expect(clone(d)).toEqual(d);
     expect(clone(d) === d).toBeFalsy();
   });
+  it('Object with methods', () => {
+    class Foo {
+      constructor(public foo = '') {}
+      method() { return this.foo; }
+    }
+    const foo = new Foo('test');
+    const clonedFoo = clone(foo);
+    expect(clonedFoo).toEqual(foo);
+    expect(clonedFoo === foo).toBeFalsy();
+    // method of the base class have been copied
+    expect(clonedFoo.method).toBeTruthy();
+    expect(clonedFoo.method()).toEqual(foo.method());
+  });
+  it('Deep object', () => {
+    class Foo {
+      constructor(public foo = '') {}
+    }
+    class Bar {
+      constructor(public bar = '', public foo = new Foo(bar)) {}
+    }
+    const bar = new Bar('test');
+    const clonedBar = clone(bar);
+    expect(clonedBar).toEqual(bar);
+    expect(clonedBar === bar).toBeFalsy();
+    // properties of the base class have been deep copied
+    expect(clonedBar.foo).toEqual(bar.foo);
+    expect(clonedBar.foo === bar.foo).toBeFalsy();
+  });
 
   it('Enumerable getter', () => {
     const d = {};

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -118,6 +118,13 @@ export function clone(value: any): any {
     return value.slice(0).map(v => clone(v));
   }
 
+  // best way to clone a js object maybe
+  // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
+  const proto = Object.getPrototypeOf(value);
+  let c = Object.create(proto);
+  c = Object.setPrototypeOf(c, proto);
+  // need to make a deep copy so we dont use Object.assign
+  // also Object.assign wont copy property descriptor exactly
   return Object.keys(value).reduce((newVal, prop) => {
     const propDescriptor = Object.getOwnPropertyDescriptor(value, prop);
 
@@ -128,7 +135,7 @@ export function clone(value: any): any {
     }
 
     return newVal;
-  }, {});
+  }, c);
 }
 
 export function defineHiddenProp(field, prop, defaultValue) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

its a fix, its also a clean up of PR #1720 and it fixes #1719 

**What is the current behavior? (You can also link to an open issue here)**

 see #1719

**What is the new behavior (if this is a feature change)?**

ensure the `clone` method creates an object of the same `type` when this type knows how to clone itself

for example, for a class Foo that implements a method `clone`
```ts
import { clone } from 'utils';
class Foo {
  constructor(public name: string) {}
  clone() { return new Foo(this.name); }
  isFoo() { return true; }
}
const foo = new Foo('test');
const clonedFoo = clone(foo);
console.log(clonedFoo.name); // 'test'
console.log(clonedFoo.isFoo()); // true
```

but for a class that doesn't, the current behavior is unchanged, the clone method copies all properties but not the methods and the type of the original value is lost

```ts
import { clone } from 'utils';
class Bar {
  constructor(public name: string) {}
  isBar() { return true; }
}
const bar = new Bar('test');
const clonedBar = clone(bar);
console.log(clonedBar.isBar()); // throws
```

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
  - i think it does, but i couldn't use `npm run commit` command
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
  - see remark
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

i have issue with the `npm run build`, it fails during ` node .config/build.js` because it needs `cp`

```
> @ngx-formly/common@5.3.0 copy:schematics D:\sites\ngx-formly
> cpr src/schematics dist/@ngx-formly/schematics --delete-first --filter node_modules/
'cp' is not recognized as an internal or external command,
```
and `cp` is not recognize on my win 10 machine.

it comes from [l19 of .config/build.js](https://github.com/ngx-formly/ngx-formly/blob/v5/.config/build.js#L19)
```js
  execSync(`cp README.md ${packagePath}`);
```
maybe using fs-extra or any other way to copy via node ([see stack overflow](https://stackoverflow.com/questions/11293857/fastest-way-to-copy-file-in-node-js)) instead of using `execSync('cp ...')` would ensure the dev env is portable to any OS

**Please provide a screenshot of this feature before and after your code changes, if applicable.**

not applicable

**Other information**:

i didnt use the one-liner for cloning cuz it did a shallow copy and that broke a test, also it didnt define enumerzable getters, which broke an other test
