### PR TITLE
fix(core): fixed removing items of initially full array (#1777)

### DIFF
--- a/src/core/src/lib/extensions/field-form/field-form.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.ts
@@ -8,7 +8,7 @@ import { registerControl } from './utils';
 export class FieldFormExtension implements FormlyExtension {
   onPopulate(field: FormlyFieldConfigCache) {
     // TODO: add an option to skip extension
-    if (field.fieldArray) {
+    if (field.fieldArray || field.type === 'array') {
       return;
     }
 


### PR DESCRIPTION
Bug fix

Current behavior:
https://github.com/ngx-formly/ngx-formly/issues/1777
When we create a form that contains an array and this array if initially full, its items cannot be removed.

New behavior:
We can remove items of initially full array.