### PR TITLE
fix(json-schema): set valid fieldArray when additionalItems is empty

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -170,13 +170,15 @@ describe('Service: FormlyJsonschema', () => {
         const childConfig: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'string', defaultValue: undefined };
         const childConfig2: FormlyFieldConfig = { templateOptions: { ...emmptyTemplateOptions }, type: 'number', defaultValue: undefined, parsers: [jasmine.any(Function)] };
 
+        expect(config.type).toEqual('array');
         expect(config.fieldArray).toEqual(childConfig);
         // TODO: is this the best way to test this?
         // artificially increase the length of the fieldGroup
         // since the getter that is defined is based on that.
         config.fieldGroup.push(null);
         expect(config.fieldArray).toEqual(childConfig2);
-        expect(config.type).toEqual('array');
+        config.fieldGroup.push(null);
+        expect(config.fieldArray).toEqual({});
       });
 
       it('supports array additionalitems wheh array items are defined as an array of schemas', () => {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -137,7 +137,7 @@ export class FormlyJsonschema {
 
             return itemSchema
               ? this._toFieldConfig(<JSONSchema7> itemSchema, options)
-              : null;
+              : {};
           },
           enumerable: true,
           configurable: true,


### PR DESCRIPTION
fix #1777
