### PR TITLE
Allow custom-inline for checkbox, radio and multicheckbox

### DIFF
--- a/src/bootstrap/src/lib/types/checkbox.ts
+++ b/src/bootstrap/src/lib/types/checkbox.ts
@@ -4,7 +4,9 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'formly-field-checkbox',
   template: `
-    <div class="custom-control custom-checkbox">
+    <div class="custom-control custom-checkbox"
+         [ngClass]="{'custom-control-inline': to.formCheck === 'custom-inline'}"
+    >
       <input class="custom-control-input" type="checkbox"
         [class.is-invalid]="showError"
         [indeterminate]="to.indeterminate && formControl.value === null"
@@ -22,6 +24,7 @@ export class FormlyFieldCheckbox extends FieldType {
     templateOptions: {
       indeterminate: true,
       hideLabel: true,
+      formCheck: 'custom', // custom | custom-inline
     },
   };
 }

--- a/src/bootstrap/src/lib/types/multicheckbox.ts
+++ b/src/bootstrap/src/lib/types/multicheckbox.ts
@@ -23,7 +23,7 @@ import { FieldType } from '@ngx-formly/core';
           {{ option.label }}
         </label>
       </div>
-    <div>
+    </div>
   `,
 })
 export class FormlyFieldMultiCheckbox extends FieldType {

--- a/src/bootstrap/src/lib/types/multicheckbox.ts
+++ b/src/bootstrap/src/lib/types/multicheckbox.ts
@@ -6,19 +6,19 @@ import { FieldType } from '@ngx-formly/core';
   template: `
     <div>
       <div *ngFor="let option of to.options | formlySelectOptions:field | async; let i = index;"
-        [ngClass]="{ 'form-check': to.formCheck !== 'custom', 'form-check-inline': to.formCheck === 'inline', 'custom-control custom-checkbox': to.formCheck === 'custom' }"
+        [ngClass]="{ 'form-check': to.formCheck !== 'custom' && to.formCheck !== 'custom-inline', 'form-check-inline': to.formCheck === 'inline', 'custom-control custom-checkbox': to.formCheck === 'custom' || to.formCheck === 'custom', 'custom-control-inline': to.formCheck === 'custom-inline' }"
       >
         <input type="checkbox"
           [id]="id + '_' + i"
-          [class.form-check-input]="to.formCheck !== 'custom'"
-          [class.custom-control-input]="to.formCheck === 'custom'"
+          [class.form-check-input]="to.formCheck !== 'custom' && to.formCheck !== 'custom-inline'"
+          [class.custom-control-input]="to.formCheck === 'custom' || to.formCheck === 'custom-inline'"
           [value]="option.value"
           [checked]="formControl.value && (this.to.type === 'array' ? formControl.value.includes(option.value) : formControl.value[option.value])"
           [formlyAttributes]="field"
           (change)="onChange(option.value, $event.target.checked)">
         <label
-          [class.form-check-label]="to.formCheck !== 'custom'"
-          [class.custom-control-label]="to.formCheck === 'custom'"
+          [class.form-check-label]="to.formCheck !== 'custom' && to.formCheck !== 'custom-inline'"
+          [class.custom-control-label]="to.formCheck === 'custom' || to.formCheck === 'custom-inline'"
           [for]="id + '_' + i">
           {{ option.label }}
         </label>
@@ -30,7 +30,7 @@ export class FormlyFieldMultiCheckbox extends FieldType {
   defaultOptions = {
     templateOptions: {
       options: [],
-      formCheck: 'custom', // 'custom' | 'stacked' | 'inline'
+      formCheck: 'custom', // 'custom' | 'stacked' | 'inline' | 'custom-inline'
     },
   };
 

--- a/src/bootstrap/src/lib/types/radio.ts
+++ b/src/bootstrap/src/lib/types/radio.ts
@@ -6,12 +6,12 @@ import { FieldType } from '@ngx-formly/core';
   template: `
     <div>
       <div *ngFor="let option of to.options | formlySelectOptions:field | async; let i = index;"
-        [ngClass]="{ 'form-check': to.formCheck !== 'custom', 'form-check-inline': to.formCheck === 'inline', 'custom-control custom-radio': to.formCheck === 'custom' }"
+        [ngClass]="{ 'form-check': to.formCheck !== 'custom' && to.formCheck !== 'custom-inline', 'form-check-inline': to.formCheck === 'inline', 'custom-control custom-radio': to.formCheck === 'custom' || to.formCheck === 'custom-inline', 'custom-control-inline': to.formCheck === 'custom-inline' }"
       >
         <input type="radio"
           [id]="id + '_' + i"
-          [class.form-check-input]="to.formCheck !== 'custom'"
-          [class.custom-control-input]="to.formCheck === 'custom'"
+          [class.form-check-input]="to.formCheck !== 'custom' && to.formCheck !== 'custom-inline'"
+          [class.custom-control-input]="to.formCheck === 'custom' || to.formCheck === 'custom-inline'"
           [name]="field.name || id"
           [class.is-invalid]="showError"
           [attr.value]="option.value"
@@ -19,8 +19,8 @@ import { FieldType } from '@ngx-formly/core';
           [formControl]="formControl"
           [formlyAttributes]="field">
         <label
-          [class.form-check-label]="to.formCheck !== 'custom'"
-          [class.custom-control-label]="to.formCheck === 'custom'"
+          [class.form-check-label]="to.formCheck !== 'custom' && to.formCheck !== 'custom-inline'"
+          [class.custom-control-label]="to.formCheck === 'custom' || to.formCheck === 'custom-inline'"
           [for]="id + '_' + i">
           {{ option.label }}
         </label>
@@ -32,7 +32,7 @@ export class FormlyFieldRadio extends FieldType {
   defaultOptions = {
     templateOptions: {
       options: [],
-      formCheck: 'custom', // 'custom' | 'stacked' | 'inline'
+      formCheck: 'custom', // 'custom' | 'stacked' | 'inline' | 'custom-inline'
     },
   };
 }


### PR DESCRIPTION
This is a fairly simple change which allows for custom-inline to be added as an option to the checkbox, radio and multicheckbox fields for bootstrap.

See: https://getbootstrap.com/docs/4.3/components/forms/#inline-1