### PR TITLE
refactor: clean up cascaded-selected example

### DIFF
--- a/demo/src/app/examples/other/cascaded-select/app.component.html
+++ b/demo/src/app/examples/other/cascaded-select/app.component.html
@@ -1,4 +1,4 @@
 <form [formGroup]="form" (ngSubmit)="submit()">
-  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
-  <button type="submit" class="btn btn-primary submit-button" [disabled]="!form.valid">Submit</button>
+  <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
+  <button type="submit" class="btn btn-primary" [disabled]="!form.valid">Submit</button>
 </form>


### PR DESCRIPTION
Hello, this PR is composed by minor clean up in the `cascaded-selected` example. It:

- removes the `subscribe`s, `OnDestroy` and some unnecessary variables, css classes and inputs;
- changes wrong variable names;
- creates a model interface and use it instead of `any`.