### PR TITLE
fix: make FormlyModule ModuleWithProviders generic for ng9 support

### DIFF
--- a/src/core/src/lib/core.module.ts
+++ b/src/core/src/lib/core.module.ts
@@ -43,7 +43,7 @@ export function defaultFormlyConfig(formlyConfig: FormlyConfig): ConfigOption {
   imports: [CommonModule],
 })
 export class FormlyModule {
-  static forRoot(config: ConfigOption = {}): ModuleWithProviders {
+  static forRoot(config: ConfigOption = {}): ModuleWithProviders<FormlyModule> {
     return {
       ngModule: FormlyModule,
       providers: [
@@ -56,7 +56,7 @@ export class FormlyModule {
     };
   }
 
-  static forChild(config: ConfigOption = {}): ModuleWithProviders {
+  static forChild(config: ConfigOption = {}): ModuleWithProviders<FormlyModule> {
     return {
       ngModule: FormlyModule,
       providers: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes ability to use ng9 due to new requirement that ModuleWithProviders is generic: https://github.com/angular/angular/pull/33187

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
