### PR TITLE
fix(core): ignore default debounce when using updateOn blur/submit

### DIFF
--- a/src/core/src/lib/components/formly.form.spec.ts
+++ b/src/core/src/lib/components/formly.form.spec.ts
@@ -173,6 +173,28 @@ describe('FormlyForm Component', () => {
       subscription.unsubscribe();
     });
 
+    it('should ignore default debounce when using "blur" or "submit"', () => {
+      app.fields = [{
+        key: 'city',
+        type: 'text',
+        modelOptions: {
+          debounce: { default: 5 },
+          updateOn: 'blur',
+        },
+      }];
+
+      const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
+      const spy = jasmine.createSpy('model change spy');
+      const subscription = fixture.componentInstance.formlyForm.modelChange.subscribe(spy);
+
+      app.form.get('city').patchValue('***');
+
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({ city: '***' });
+      subscription.unsubscribe();
+    });
+
     it('should emit `modelChange` after debounce time', fakeAsync(() => {
       app.fields = [{
         key: 'city',

--- a/src/core/src/lib/components/formly.form.ts
+++ b/src/core/src/lib/components/formly.form.ts
@@ -173,9 +173,13 @@ export class FormlyForm implements DoCheck, OnChanges, OnDestroy {
     fields.forEach(field => {
       if (field.key && !field.fieldGroup) {
         const control = field.formControl;
-        const valueChanges = field.modelOptions.debounce && field.modelOptions.debounce.default
-          ? control.valueChanges.pipe(debounceTime(field.modelOptions.debounce.default))
-          : control.valueChanges;
+        let valueChanges = control.valueChanges;
+
+        const { updateOn, debounce } = field.modelOptions;
+        if ((!updateOn || updateOn === 'change') && debounce && debounce.default > 0) {
+          valueChanges = control.valueChanges.pipe(debounceTime(debounce.default));
+        }
+
 
         this.modelChangeSubs.push(valueChanges.subscribe(value => {
           // workaround for https://github.com/angular/angular/issues/13792


### PR DESCRIPTION
fix #1898
