### PR TITLE
feat(core): use undefined as defaultValue for control to match the model

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -16,7 +16,7 @@ export interface FormlyJsonschemaOptions {
 }
 
 function isEmpty(v: any) {
-  return v === '' || v === undefined || v === null;
+  return v === '' || v == null;
 }
 
 function clearFieldModel(field: FormlyFieldConfig) {

--- a/src/core/src/lib/components/formly.form.spec.ts
+++ b/src/core/src/lib/components/formly.form.spec.ts
@@ -213,7 +213,7 @@ describe('FormlyForm Component', () => {
           },
         ],
       });
-      expect(form.value).toEqual({ title: null });
+      expect(form.value).toEqual({ title: undefined });
 
       setInputs({ model: { title: '***' } });
       expect(form.value).toEqual({ title: '***' });
@@ -300,12 +300,12 @@ describe('FormlyForm Component', () => {
 
       const inputDebugEl = query('input');
 
-      expect(form.get('name').value).toBeNull();
+      expect(form.get('name').value).toBeUndefined();
 
       inputDebugEl.triggerEventHandler('input', { target: { value: 'First' } });
       detectChanges();
 
-      expect(form.get('name').value).toBeNull();
+      expect(form.get('name').value).toBeUndefined();
 
       inputDebugEl.triggerEventHandler('blur', {});
       detectChanges();
@@ -326,13 +326,13 @@ describe('FormlyForm Component', () => {
 
       const inputDebugEl = query('input');
 
-      expect(form.get('name').value).toBeNull();
+      expect(form.get('name').value).toBeUndefined();
       inputDebugEl.triggerEventHandler('input', { target: { value: 'First' } });
 
       inputDebugEl.triggerEventHandler('blur', {});
       detectChanges();
 
-      expect(form.get('name').value).toBeNull();
+      expect(form.get('name').value).toBeUndefined();
 
       query('form').triggerEventHandler('submit', {});
       detectChanges();

--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -12,7 +12,7 @@ import {
   reverseDeepMerge,
   defineHiddenProp,
   clone,
-  isNullOrUndefined,
+  isNil,
 } from '../../utils';
 import { Subject } from 'rxjs';
 
@@ -88,7 +88,7 @@ export class CoreExtension implements FormlyExtension {
 
     if (!options.resetModel) {
       options.resetModel = (model?: any) => {
-        model = clone(isNullOrUndefined(model) ? options._initialModel : model);
+        model = clone(isNil(model) ? options._initialModel : model);
         if (field.model) {
           Object.keys(field.model).forEach(k => delete field.model[k]);
           Object.assign(field.model, model || {});

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -3,7 +3,7 @@ import {
   FormlyValueChangeEvent,
   FormlyFieldConfigCache,
 } from '../../components/formly.field.config';
-import { isObject, isNullOrUndefined, isFunction, defineHiddenProp, wrapProperty } from '../../utils';
+import { isObject, isNil, isFunction, defineHiddenProp, wrapProperty } from '../../utils';
 import { evalExpression, evalStringExpression, evalExpressionValueSetter } from './utils';
 import { Observable } from 'rxjs';
 import { FormlyExtension } from '../../services/formly.config';
@@ -169,11 +169,7 @@ export class FieldExpressionExtension implements FormlyExtension {
           const path = key.replace(/^model\./, ''),
             control = field.key && field.key === path ? field.formControl : field.form.get(path);
 
-          if (
-            control &&
-            !(isNullOrUndefined(control.value) && isNullOrUndefined(expressionValue)) &&
-            control.value !== expressionValue
-          ) {
+          if (control && !(isNil(control.value) && isNil(expressionValue)) && control.value !== expressionValue) {
             control.patchValue(expressionValue);
           }
         }
@@ -184,7 +180,7 @@ export class FieldExpressionExtension implements FormlyExtension {
   }
 
   private checkFieldVisibilityChange(field: FormlyFieldConfigCache, ignoreCache): boolean {
-    if (!field || isNullOrUndefined(field.hideExpression)) {
+    if (!field || isNil(field.hideExpression)) {
       return false;
     }
 

--- a/src/core/src/lib/extensions/field-form/field-form.spec.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.spec.ts
@@ -19,6 +19,16 @@ function buildField({ model, options, form: formControl, ...field }: FormlyField
 
 describe('FieldFormExtension', () => {
   describe('assign model field to form control', () => {
+    it('should match undefined model value', () => {
+      const { form } = buildField({
+        model: { foo: null },
+        fieldGroup: [{ key: 'foo' }, { key: 'bar' }],
+      });
+
+      expect(form.get('bar').value).toBeUndefined();
+      expect(form.get('foo').value).toBeNull();
+    });
+
     it('should assign model for nested field key', () => {
       const { form } = buildField({
         key: 'address.city',

--- a/src/core/src/lib/extensions/field-form/field-form.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.ts
@@ -42,7 +42,7 @@ export class FieldFormExtension implements FormlyExtension {
       const controlOptions: AbstractControlOptions = { updateOn: field.modelOptions.updateOn };
       control = field.fieldGroup
         ? new FormGroup({}, controlOptions)
-        : new FormControl(getFieldValue(field), controlOptions);
+        : new FormControl({ value: getFieldValue(field) }, controlOptions);
     }
 
     registerControl(field, control);

--- a/src/core/src/lib/extensions/field-form/utils.ts
+++ b/src/core/src/lib/extensions/field-form/utils.ts
@@ -1,6 +1,6 @@
 import { FormArray, FormGroup, FormControl } from '@angular/forms';
 import { FormlyFieldConfig } from '../../core';
-import { getKeyPath, getFieldValue, isNullOrUndefined, defineHiddenProp } from '../../utils';
+import { getKeyPath, getFieldValue, isNil, defineHiddenProp } from '../../utils';
 
 export function unregisterControl(field: FormlyFieldConfig) {
   const form = field.formControl.parent as FormArray | FormGroup;
@@ -60,11 +60,7 @@ export function registerControl(field: FormlyFieldConfig, control?: any) {
   }
 
   const value = getFieldValue(field);
-  if (
-    !(isNullOrUndefined(control.value) && isNullOrUndefined(value)) &&
-    control.value !== value &&
-    control instanceof FormControl
-  ) {
+  if (!(isNil(control.value) && isNil(value)) && control.value !== value && control instanceof FormControl) {
     control.patchValue(value, { emitEvent: false });
   }
   const key = paths[paths.length - 1];

--- a/src/core/src/lib/templates/field-array.type.ts
+++ b/src/core/src/lib/templates/field-array.type.ts
@@ -1,6 +1,6 @@
 import { FormArray } from '@angular/forms';
 import { FieldType } from './field.type';
-import { clone, isNullOrUndefined, assignFieldValue, getFieldValue } from '../utils';
+import { clone, isNil, assignFieldValue, getFieldValue } from '../utils';
 import { FormlyFieldConfig } from '../components/formly.field.config';
 import { FormlyExtension } from '../services/formly.config';
 import { registerControl, unregisterControl } from '../extensions/field-form/utils';
@@ -31,7 +31,7 @@ export abstract class FieldArrayType<F extends FormlyFieldConfig = FormlyFieldCo
   }
 
   add(i?: number, initialModel?: any) {
-    i = isNullOrUndefined(i) ? this.field.fieldGroup.length : i;
+    i = isNil(i) ? this.field.fieldGroup.length : i;
     if (!this.model) {
       assignFieldValue(this.field, []);
     }

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -69,7 +69,7 @@ export function getFieldValue(field: FormlyFieldConfig): any {
 export function reverseDeepMerge(dest: any, ...args: any[]) {
   args.forEach(src => {
     for (const srcArg in src) {
-      if (isNullOrUndefined(dest[srcArg]) || isBlankString(dest[srcArg])) {
+      if (isNil(dest[srcArg]) || isBlankString(dest[srcArg])) {
         dest[srcArg] = clone(src[srcArg]);
       } else if (objAndSameType(dest[srcArg], src[srcArg])) {
         reverseDeepMerge(dest[srcArg], src[srcArg]);
@@ -79,8 +79,9 @@ export function reverseDeepMerge(dest: any, ...args: any[]) {
   return dest;
 }
 
-export function isNullOrUndefined(value: any) {
-  return value === undefined || value === null;
+// check a value is null or undefined
+export function isNil(value: any) {
+  return value == null;
 }
 
 export function isUndefined(value: any) {

--- a/src/ui/bootstrap/checkbox/src/checkbox.type.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.ts
@@ -9,7 +9,7 @@ import { FieldType } from '@ngx-formly/core';
         class="custom-control-input"
         type="checkbox"
         [class.is-invalid]="showError"
-        [indeterminate]="to.indeterminate && formControl.value === null"
+        [indeterminate]="to.indeterminate && formControl.value == null"
         [formControl]="formControl"
         [formlyAttributes]="field"
       />

--- a/src/ui/bootstrap/select/src/select.spec.ts
+++ b/src/ui/bootstrap/select/src/select.spec.ts
@@ -42,6 +42,24 @@ describe('ui-bootstrap: Select Type', () => {
     expect(field.formControl.value).toEqual(1);
   });
 
+  it('should select placeholder option when value is undefined', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'select',
+      templateOptions: {
+        placeholder: 'Placeholder option',
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+        ],
+      },
+    });
+
+    const { options, selectedIndex } = query<HTMLSelectElement>('select').nativeElement;
+    expect(options[selectedIndex]).toBeDefined();
+    expect(options[selectedIndex].text).toEqual('Placeholder option');
+  });
+
   describe('render select options', () => {
     it('should correctly bind to a static array of data', () => {
       const { queryAll } = renderComponent({

--- a/src/ui/bootstrap/select/src/select.type.ts
+++ b/src/ui/bootstrap/select/src/select.type.ts
@@ -32,7 +32,7 @@ import { FieldType } from '@ngx-formly/core';
         [class.is-invalid]="showError"
         [formlyAttributes]="field"
       >
-        <option *ngIf="to.placeholder" [ngValue]="null">{{ to.placeholder }}</option>
+        <option *ngIf="to.placeholder" [ngValue]="undefined">{{ to.placeholder }}</option>
         <ng-container *ngFor="let item of to.options | formlySelectOptions: field | async">
           <optgroup *ngIf="item.group" label="{{ item.label }}">
             <option *ngFor="let child of item.group" [ngValue]="child.value" [disabled]="child.disabled">
@@ -53,11 +53,11 @@ export class FormlyFieldSelect extends FieldType implements AfterViewChecked {
 
   // workaround for https://github.com/angular/angular/issues/10010
   ngAfterViewChecked() {
-    if (!this.to.multiple && !this.to.placeholder && this.formControl.value === null) {
+    if (!this.to.multiple && !this.to.placeholder && this.formControl.value == null) {
       const selectEl = this.select.nativeElement;
       if (
         selectEl.selectedIndex !== -1 &&
-        (!selectEl.options[selectEl.selectedIndex] || selectEl.options[selectEl.selectedIndex].value !== null)
+        (!selectEl.options[selectEl.selectedIndex] || selectEl.options[selectEl.selectedIndex].value != null)
       ) {
         this.select.nativeElement.selectedIndex = -1;
       }

--- a/src/ui/material/checkbox/src/checkbox.type.ts
+++ b/src/ui/material/checkbox/src/checkbox.type.ts
@@ -10,7 +10,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
       [id]="id"
       [formlyAttributes]="field"
       [tabindex]="to.tabindex || 0"
-      [indeterminate]="to.indeterminate && formControl.value === null"
+      [indeterminate]="to.indeterminate && formControl.value == null"
       [color]="to.color"
       [labelPosition]="to.align || to.labelPosition"
     >

--- a/src/ui/material/form-field/src/field.type.ts
+++ b/src/ui/material/form-field/src/field.type.ts
@@ -98,7 +98,7 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
     return this.formControl as any;
   }
   get empty() {
-    return this.value === undefined || this.value === null || this.value === '';
+    return this.value == null || this.value === '';
   }
   get shouldLabelFloat() {
     return this.focused || !this.empty;

--- a/src/ui/material/native-select/src/native-select.type.ts
+++ b/src/ui/material/native-select/src/native-select.type.ts
@@ -13,7 +13,7 @@ import { MatInput } from '@angular/material/input';
       [formControl]="formControl"
       [formlyAttributes]="field"
     >
-      <option *ngIf="to.placeholder" [ngValue]="null">{{ to.placeholder }}</option>
+      <option *ngIf="to.placeholder" [ngValue]="undefined">{{ to.placeholder }}</option>
       <ng-container *ngFor="let item of to.options | formlySelectOptions: field | async">
         <optgroup *ngIf="item.group" label="{{ item.label }}">
           <option *ngFor="let child of item.group" [ngValue]="child.value" [disabled]="child.disabled">


### PR DESCRIPTION
BREAKING CHANGE: The initial value of the created FormControl has been changed from `null` to
`undefined` to match the field model value.

re #1861
