### PR TITLE
fix(core): check if content is defined

### DIFF
--- a/src/core/src/lib/components/formly.form.ts
+++ b/src/core/src/lib/components/formly.form.ts
@@ -40,7 +40,7 @@ export class FormlyForm implements DoCheck, OnChanges, OnDestroy {
 
   @Output() modelChange = new EventEmitter<any>();
   @ViewChild('content') set content(content: ElementRef<HTMLElement>) {
-    if (content.nativeElement.nextSibling) {
+    if (content && content.nativeElement.nextSibling) {
       console.warn(`NgxFormly: content projection for 'formly-form' component is deprecated since v5.5, you should avoid passing content inside the 'formly-form' tag.`);
     }
   }


### PR DESCRIPTION
check if content is defined before accessing its properties

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
It breaks trying to access `nativeElement` property of `content`, but `content` is not defined.


**What is the new behavior (if this is a feature change)?**
N/A


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
N/A


**Other information**:
Angular upgrade from v7.x.x to v8.0.0 in our project caused this bug. I believe this happens because angular introduced `static: true / false` concept for `@ViewChild`.

AngularJS: 1.6.5
Angular: 8.0.0
@ngx-formly/core: 5.5.4