### PR TITLE
fix(material): remove textarea autosize attributes when disabled

### DIFF
--- a/src/material/textarea/src/textarea.type.ts
+++ b/src/material/textarea/src/textarea.type.ts
@@ -19,7 +19,9 @@ import { MAT_INPUT_VALUE_ACCESSOR } from '@angular/material/input';
       [readonly]="to.readonly"
       [cdkTextareaAutosize]="to.autosize"
       [cdkAutosizeMinRows]="to.autosizeMinRows"
-      [cdkAutosizeMaxRows]="to.autosizeMaxRows">
+      [cdkAutosizeMaxRows]="to.autosizeMaxRows"
+      [class.cdk-textarea-autosize]="to.autosize"
+      >
     </textarea>
   `,
   providers: [


### PR DESCRIPTION
fix #2042
