### PR TITLE
feat(json-schema): adding types

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -442,6 +442,30 @@ describe('Service: FormlyJsonschema', () => {
         expect(config.type).toBe(schema.type);
       });
 
+      describe('should support string types with format', () => {
+        it('should support type time', () => {
+          const schema: JSONSchema7 = {
+            type: 'string',
+            format: 'time',
+          };
+
+          const { type } = formlyJsonschema.toFieldConfig(schema);
+
+          expect(type).toEqual('time');
+        });
+
+        it('should support type date', () => {
+          const schema: JSONSchema7 = {
+            type: 'string',
+            format: 'date',
+          };
+
+          const { type } = formlyJsonschema.toFieldConfig(schema);
+
+          expect(type).toEqual('date');
+        });
+      });
+
       describe('should support enum type', () => {
         it('should support enum as strig array values', () => {
           const schemaStringEnum: JSONSchema7 = {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -410,8 +410,10 @@ export class FormlyJsonschema {
     return [deps, schemaDeps];
   }
 
-  private guessType(schema: JSONSchema7) {
+  private guessType(schema: JSONSchema7): string {
     const type = schema.type as JSONSchema7TypeName;
+    const format = schema.format;
+
     if (!type && schema.properties) {
       return 'object';
     }
@@ -424,6 +426,10 @@ export class FormlyJsonschema {
       if (type.length === 2 && type.indexOf('null') !== -1) {
         return type[type[0] === 'null' ? 1 : 0];
       }
+    }
+
+    if (type === 'string' && format !== undefined) {
+      return format;
     }
 
     return type;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR expands the returned types by adding `date` and `time` type formats.

**What is the current behavior? (You can also link to an open issue here)**

If your JSON Schema defines a property like `{ "type": "string", "format": "time" }`, then Formly returns the type "string" only.
This means that you don't know if the returned property is supposed to be displayed as a regular input field (current standard behaviour), a time field or a date field.

**What is the new behavior (if this is a feature change)?**

Formly now additionally returns the types `time` or `date` if the JSON Schema provides properties with the formats `time` or `date` respectively.

According to the latest JSON Schema draft an extension of the instance type is possible:

> "Note that JSON Schema vocabularies are free to define their own extended type system."
> https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.4.2.1

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Other information**:

In case this is classified as a breaking change you could add a flag like "extended instance types" that makes it possible to return `string`, `time` and `date` instead of only `string`?