### PR TITLE
feat(): add primeng multiselect and filter support

### DIFF
--- a/demo/src/app/ui/common/select/app.component.ts
+++ b/demo/src/app/ui/common/select/app.component.ts
@@ -20,12 +20,12 @@ export class AppComponent {
         description: 'Description',
         required: true,
         options: [
-          { value: 1, label: 'Option 1'  },
-          { value: 2, label: 'Option 2'  },
-          { value: 3, label: 'Option 3'  },
-          { value: 4, label: 'Option 4'  },
+          { value: 1, label: 'Option 1' },
+          { value: 2, label: 'Option 2' },
+          { value: 3, label: 'Option 3' },
+          { value: 4, label: 'Option 4' },
         ],
-        filterable: true
+        filterable: true,
       },
     },
     {
@@ -35,15 +35,15 @@ export class AppComponent {
         label: 'Select Multiple',
         placeholder: 'Placeholder',
         description: 'Description',
-        required: true,        
+        required: true,
         selectAllOption: 'Select All',
         options: [
-          { value: 1, label: 'Option 1'  },
-          { value: 2, label: 'Option 2'  },
-          { value: 3, label: 'Option 3'  },
-          { value: 4, label: 'Option 4'  },
+          { value: 1, label: 'Option 1' },
+          { value: 2, label: 'Option 2' },
+          { value: 3, label: 'Option 3' },
+          { value: 4, label: 'Option 4' },
         ],
-        filterable: true
+        filterable: true,
       },
     },
   ];

--- a/demo/src/app/ui/common/select/app.component.ts
+++ b/demo/src/app/ui/common/select/app.component.ts
@@ -25,17 +25,17 @@ export class AppComponent {
           { value: 3, label: 'Option 3'  },
           { value: 4, label: 'Option 4'  },
         ],
+        filterable: true
       },
     },
     {
       key: 'select_multi',
-      type: 'select',
+      type: 'multi-select',
       templateOptions: {
         label: 'Select Multiple',
         placeholder: 'Placeholder',
         description: 'Description',
-        required: true,
-        multiple: true,
+        required: true,        
         selectAllOption: 'Select All',
         options: [
           { value: 1, label: 'Option 1'  },
@@ -43,6 +43,7 @@ export class AppComponent {
           { value: 3, label: 'Option 3'  },
           { value: 4, label: 'Option 4'  },
         ],
+        filterable: true
       },
     },
   ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -5178,7 +5178,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/src/core/src/lib/templates/field-array.type.spec.ts
+++ b/src/core/src/lib/templates/field-array.type.spec.ts
@@ -5,6 +5,7 @@ import { FormGroup, ReactiveFormsModule, FormArray } from '@angular/forms';
 import { FormlyModule, FormlyForm, FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { FieldArrayType } from './field-array.type';
 import { FormlyFieldText } from '../components/formly.field.spec';
+import { By } from '@angular/platform-browser';
 
 function createFormlyTestComponent() {
   return createGenericTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>', TestComponent);
@@ -61,6 +62,30 @@ describe('Array Field Type', () => {
     fixture.nativeElement.querySelector('#remove-0').click();
     fixture.detectChanges();
     expect(app.form.dirty).toBeTruthy();
+  });
+
+  it('should not mark the form dirty on Add/Remove', () => {
+    app.model = { array: null };
+    app.fields = [{
+      key: 'array',
+      type: 'array',
+    }];
+
+    const fixture = createFormlyTestComponent();
+    expect(app.form.dirty).toBeFalsy();
+
+    const arrayType = fixture.debugElement.query(By.css('formly-array-type'))
+      .componentInstance as ArrayTypeComponent;
+
+    arrayType.add(null, null, { markAsDirty: false });
+    fixture.detectChanges();
+    expect(app.form.dirty).toBeFalsy();
+
+    app.form.markAsPristine();
+
+    arrayType.remove(0, { markAsDirty: false });
+    fixture.detectChanges();
+    expect(app.form.dirty).toBeFalsy();
   });
 
   it('should work with nullable model', () => {

--- a/src/core/src/lib/templates/field-array.type.ts
+++ b/src/core/src/lib/templates/field-array.type.ts
@@ -22,7 +22,7 @@ export abstract class FieldArrayType<F extends FormlyFieldConfig = FormlyFieldCo
   }
 
   onPopulate(field: FormlyFieldConfig) {
-    if (!field.formControl) {
+    if (!field.formControl && field.key) {
       registerControl(field, new FormArray([], { updateOn: field.modelOptions.updateOn }));
     }
 
@@ -42,7 +42,7 @@ export abstract class FieldArrayType<F extends FormlyFieldConfig = FormlyFieldCo
     }
   }
 
-  add(i?: number, initialModel?: any) {
+  add(i?: number, initialModel?: any, { markAsDirty } = { markAsDirty: true }) {
     i = isNullOrUndefined(i) ? this.field.fieldGroup.length : i;
     if (!this.model) {
       assignModelValue(this.field.parent.model, getKeyPath(this.field), []);
@@ -51,16 +51,16 @@ export abstract class FieldArrayType<F extends FormlyFieldConfig = FormlyFieldCo
     this.model.splice(i, 0, initialModel ? clone(initialModel) : undefined);
 
     (<any> this.options)._buildForm(true);
-    this.formControl.markAsDirty();
+    markAsDirty && this.formControl.markAsDirty();
   }
 
-  remove(i: number) {
+  remove(i: number, { markAsDirty } = { markAsDirty: true }) {
     this.model.splice(i, 1);
     unregisterControl(this.field.fieldGroup[i], true);
     this.field.fieldGroup.splice(i, 1);
     this.field.fieldGroup.forEach((f, key) => f.key = `${key}`);
 
     (<any> this.options)._buildForm(true);
-    this.formControl.markAsDirty();
+    markAsDirty && this.formControl.markAsDirty();
   }
 }

--- a/src/core/src/lib/templates/field-template.type.ts
+++ b/src/core/src/lib/templates/field-template.type.ts
@@ -1,8 +1,27 @@
 import { Component } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { FieldType } from './field.type';
 
 @Component({
   selector: 'formly-template',
-  template: `<div [innerHtml]="field.template"></div>`,
+  template: `<div [innerHtml]="template"></div>`,
 })
-export class FormlyTemplateType extends FieldType {}
+export class FormlyTemplateType extends FieldType {
+  get template() {
+    if (this.field && (this.field.template !== this.innerHtml.template)) {
+      this.innerHtml = {
+        template: this.field.template,
+        content: this.to.safeHtml
+          ? this.sanitizer.bypassSecurityTrustHtml(this.field.template)
+          : this.field.template,
+      };
+    }
+
+    return this.innerHtml.content;
+  }
+
+  private innerHtml = { content: null, template: null };
+  constructor(private sanitizer: DomSanitizer) {
+    super();
+  }
+}

--- a/src/primeng/src/lib/types/multi-select.ts
+++ b/src/primeng/src/lib/types/multi-select.ts
@@ -12,14 +12,14 @@ import { FieldType } from '@ngx-formly/core';
       [formlyAttributes]="field"
       [filter]="to.filterable"
       (onChange)="to.change && to.change(field, $event)">
-    </p-multiSelect>        
+    </p-multiSelect>
   `,
 })
 export class FormlyFieldMultiSelect extends FieldType {
   defaultOptions = {
     templateOptions: { options: [] },
   };
-  constructor(){
+  constructor() {
     super();
   }
 }

--- a/src/primeng/src/lib/types/multi-select.ts
+++ b/src/primeng/src/lib/types/multi-select.ts
@@ -2,22 +2,24 @@ import { Component } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 
 @Component({
-  selector: 'formly-field-primeng-select',
+  selector: 'formly-field-primeng-multi-select',
   template: `
-    <p-dropdown
+    <p-multiSelect
       [class.ng-dirty]="showError"
-      [placeholder]="to.placeholder"
+      [filterPlaceHolder]="to.placeholder"
       [options]="to.options | formlySelectOptions:field | async"
       [formControl]="formControl"
       [formlyAttributes]="field"
-      [showClear]="!to.required"
       [filter]="to.filterable"
       (onChange)="to.change && to.change(field, $event)">
-    </p-dropdown>
+    </p-multiSelect>        
   `,
 })
-export class FormlyFieldSelect extends FieldType {
+export class FormlyFieldMultiSelect extends FieldType {
   defaultOptions = {
     templateOptions: { options: [] },
   };
+  constructor(){
+    super();
+  }
 }

--- a/src/primeng/src/lib/ui-primeng.config.ts
+++ b/src/primeng/src/lib/ui-primeng.config.ts
@@ -7,6 +7,7 @@ import {
   FormlyFieldSelect,
 } from './types/types';
 import { FormlyWrapperFormField } from './wrappers/wrappers';
+import { FormlyFieldMultiSelect } from './types/multi-select';
 
 export const FIELD_TYPE_COMPONENTS = [
   // types
@@ -15,6 +16,7 @@ export const FIELD_TYPE_COMPONENTS = [
   FormlyFieldCheckbox,
   FormlyFieldRadio,
   FormlyFieldSelect,
+  FormlyFieldMultiSelect,
 
   // wrappers
   FormlyWrapperFormField,
@@ -45,6 +47,11 @@ export const PRIME_NG_FORMLY_CONFIG: ConfigOption = {
     {
       name: 'select',
       component: FormlyFieldSelect,
+      wrappers: ['form-field'],
+    },
+    {
+      name: 'multi-select',
+      component: FormlyFieldMultiSelect,
       wrappers: ['form-field'],
     },
   ],

--- a/src/primeng/src/lib/ui-primeng.module.ts
+++ b/src/primeng/src/lib/ui-primeng.module.ts
@@ -7,6 +7,7 @@ import { InputTextareaModule } from 'primeng/inputtextarea';
 import { CheckboxModule } from 'primeng/checkbox';
 import { RadioButtonModule } from 'primeng/radiobutton';
 import { DropdownModule } from 'primeng/dropdown';
+import { MultiSelectModule } from 'primeng/multiselect';
 
 import { FormlyModule } from '@ngx-formly/core';
 import { FormlySelectModule } from '@ngx-formly/core/select';
@@ -22,7 +23,7 @@ import { PRIME_NG_FORMLY_CONFIG, FIELD_TYPE_COMPONENTS } from './ui-primeng.conf
     CheckboxModule,
     RadioButtonModule,
     DropdownModule,
-
+    MultiSelectModule,
     ReactiveFormsModule,
     FormlySelectModule,
     FormlyModule.forChild(PRIME_NG_FORMLY_CONFIG),


### PR DESCRIPTION
add filter and multiselect features for primeng select type.

Closes #1628

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature


**What is the current behavior? (You can also link to an open issue here)**
https://github.com/ngx-formly/ngx-formly/issues/1628


**What is the new behavior (if this is a feature change)?**
filter feature for primeng select run
multi-select feature for primeng run


**Please check if the PR fulfills these requirements**
- [ x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
