### PR TITLE
feat(material): mat-hint alignment support

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -92,6 +92,7 @@ export class AppComponent {
         { path: '/examples/other/advanced-layout-flex', title: 'Advanced Layout (Flex)' },
         { path: '/examples/other/nested-formly-forms', title: 'Nested Forms (fieldGroup wrapper)' },
         { path: '/examples/other/material-prefix-suffix', title: 'Material Field Prefix/Suffix' },
+        { path: '/examples/other/material-formfield-hint-align', title: 'Material Field Hint Alignment' },
         { path: '/examples/other/hide-fields-with-animations', title: 'Hide Fields with `@angular/animations`' },
         { path: '/examples/other/button', title: 'Button Type' },
         { path: '/examples/other/json-powered', title: 'JSON powered' },

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -73,6 +73,7 @@ import { SharedModule } from '../shared';
           { path: 'advanced-layout-flex', loadChildren: './other/advanced-layout-flex/config.module#ConfigModule' },
           { path: 'nested-formly-forms', loadChildren: './other/nested-formly-forms/config.module#ConfigModule' },
           { path: 'material-prefix-suffix', loadChildren: './other/material-prefix-suffix/config.module#ConfigModule' },
+          { path: 'material-formfield-hint-align', loadChildren: './other/material-formfield-hint-align/config.module#ConfigModule' },
           { path: 'hide-fields-with-animations', loadChildren: './other/hide-fields-with-animations/config.module#ConfigModule' },
           { path: 'button', loadChildren: './other/button/config.module#ConfigModule' },
           { path: 'json-powered', loadChildren: './other/json-powered/config.module#ConfigModule' },

--- a/demo/src/app/examples/other/material-formfield-hint-align/app.component.html
+++ b/demo/src/app/examples/other/material-formfield-hint-align/app.component.html
@@ -1,0 +1,6 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>
+
+<ng-template #hintStart>hintStart accepts strings and TemplateRefs and is aligned to start</ng-template>
+<ng-template #hintEnd>hintEnd accepts strings and TemplateRefs and is aligned to end</ng-template>

--- a/demo/src/app/examples/other/material-formfield-hint-align/app.component.ts
+++ b/demo/src/app/examples/other/material-formfield-hint-align/app.component.ts
@@ -1,0 +1,55 @@
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  // TODO: remove `any`, once dropping angular `V7` support.
+  @ViewChild('hintStart', <any>{ static: true }) hintStart: TemplateRef<any>;
+  // TODO: remove `any`, once dropping angular `V7` support.
+  @ViewChild('hintEnd', <any>{ static: true }) hintEnd: TemplateRef<any>;
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'Input',
+      type: 'input',
+      templateOptions: {
+        label: 'Input with string hints',
+        placeholder: 'Placeholder',
+        hintStart: 'hintStart accepts strings and TemplateRefs and is aligned to start',
+        hintEnd: 'hintEnd accepts strings and TemplateRefs and is aligned to end',
+        required: true,
+      },
+    },
+    {
+      key: 'Input2',
+      type: 'input',
+      templateOptions: {
+        label: 'Input with template hints',
+        required: true,
+      },
+      hooks: {
+        afterViewInit: (field) => {
+          field.templateOptions.hintStart = this.hintStart;
+          field.templateOptions.hintEnd = this.hintEnd;
+        },
+      },
+    },
+    {
+      key: 'Input3',
+      type: 'input',
+      templateOptions: {
+        label: 'Input with description',
+        description: 'Description field accepts strings and gets aligned to start',
+        required: true,
+      },
+    },
+  ];
+}

--- a/demo/src/app/examples/other/material-formfield-hint-align/app.module.ts
+++ b/demo/src/app/examples/other/material-formfield-hint-align/app.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyMaterialModule } from '@ngx-formly/material';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, FormlyMaterialModule, FormlyModule.forRoot()],
+  declarations: [AppComponent],
+})
+export class AppModule {}

--- a/demo/src/app/examples/other/material-formfield-hint-align/config.module.ts
+++ b/demo/src/app/examples/other/material-formfield-hint-align/config.module.ts
@@ -1,0 +1,51 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [
+            {
+              title: 'Material Field Hint Alignment',
+              description: `
+              <p>This demonstrates alignment of hints for Material FormFields.</p>
+
+              <p>The hintStart and hintEnd properties supports both string values and TemplateRefs.<br />
+              To use a TemplateRef, you can either supply it like shown in this example, or you can create an addon that creates the template for you like shown in the "Material prefix suffix" example</p>
+            `,
+              component: AppComponent,
+              files: [
+                {
+                  file: 'app.component.html',
+                  content: require('!!highlight-loader?raw=true&lang=html!./app.component.html'),
+                  filecontent: require('!!raw-loader!./app.component.html'),
+                },
+                {
+                  file: 'app.component.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.component.ts'),
+                  filecontent: require('!!raw-loader!./app.component.ts'),
+                },
+                {
+                  file: 'app.module.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.module.ts'),
+                  filecontent: require('!!raw-loader!./app.module.ts'),
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]),
+  ],
+  entryComponents: [AppComponent],
+})
+export class ConfigModule {}

--- a/src/material/form-field/src/form-field.module.ts
+++ b/src/material/form-field/src/form-field.module.ts
@@ -4,9 +4,10 @@ import { FormlyModule } from '@ngx-formly/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { FormlyWrapperFormField } from './form-field.wrapper';
+import { StringOrTemplateComponent } from './string-or-template.component';
 
 @NgModule({
-  declarations: [FormlyWrapperFormField],
+  declarations: [FormlyWrapperFormField, StringOrTemplateComponent],
   imports: [
     CommonModule,
     ReactiveFormsModule,

--- a/src/material/form-field/src/form-field.wrapper.ts
+++ b/src/material/form-field/src/form-field.wrapper.ts
@@ -28,19 +28,26 @@ interface MatFormlyFieldConfig extends FormlyFieldConfig {
         <span *ngIf="to.required && to.hideRequiredMarker !== true" class="mat-form-field-required-marker">*</span>
       </mat-label>
 
-      <ng-container matPrefix *ngIf="to.prefix || formlyField._matprefix">
-        <ng-container *ngTemplateOutlet="to.prefix ? to.prefix : formlyField._matprefix"></ng-container>
+      <ng-container matPrefix *ngIf="(to.prefix || formlyField._matprefix) as prefix">
+        <formly-string-or-template [content]="prefix"></formly-string-or-template>
       </ng-container>
 
-      <ng-container matSuffix *ngIf="to.suffix || formlyField._matsuffix">
-        <ng-container *ngTemplateOutlet="to.suffix ? to.suffix : formlyField._matsuffix"></ng-container>
+      <ng-container matSuffix *ngIf="(to.suffix || formlyField._matsuffix) as suffix">
+        <formly-string-or-template [content]="suffix"></formly-string-or-template>
       </ng-container>
 
       <mat-error>
         <formly-validation-message [field]="field"></formly-validation-message>
       </mat-error>
+
       <!-- fix https://github.com/angular/material2/issues/7737 by setting id to null  -->
-      <mat-hint *ngIf="to.description" [id]="null">{{ to.description }}</mat-hint>
+      <mat-hint *ngIf="to.description || to.hintStart as hint" [id]="null">
+        <formly-string-or-template [content]="hint"></formly-string-or-template>
+      </mat-hint>
+
+      <mat-hint *ngIf="to.hintEnd as hintEnd" [id]="null" align="end">
+        <formly-string-or-template [content]="hintEnd"></formly-string-or-template>
+      </mat-hint>
     </mat-form-field>
   `,
   providers: [{ provide: MatFormFieldControl, useExisting: FormlyWrapperFormField }],

--- a/src/material/form-field/src/string-or-template.component.ts
+++ b/src/material/form-field/src/string-or-template.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input, TemplateRef } from '@angular/core';
+
+@Component({
+  selector: 'formly-string-or-template',
+  template: `
+    <ng-container *ngIf="contentString; else template">{{ contentString }}</ng-container>
+    <ng-template #template>
+      <ng-container *ngTemplateOutlet="templateRef"></ng-container>
+    </ng-template>
+  `,
+})
+export class StringOrTemplateComponent {
+  contentString: null | string = null;
+  templateRef: null | TemplateRef<any> = null;
+
+  @Input() set content(content: string | TemplateRef<any>) {
+    if (content == null) {
+      this.templateRef = null;
+      this.contentString = null;
+    } else if (typeof content === 'string') {
+      this.templateRef = null;
+      this.contentString = content;
+    } else if (typeof content === 'object') {
+      this.contentString = null;
+      this.templateRef = content;
+    }
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds support for aligning mat-hints to the left or right (start or end).
Adds example on how to use to the docs

**What is the current behavior? (You can also link to an open issue here)**

Mat-hint is supported on form-fields through the description templateOptions property.
However, specifying the alignment of the hint is not supported.


**What is the new behavior (if this is a feature change)?**

You can display one start-aligned hint and one end-aligned hint. You can specify one or both.


**Please check if the PR fulfills these requirements**

- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**

![image](https://user-images.githubusercontent.com/8955488/78265001-29cf6c80-7504-11ea-9510-dcf793d59a07.png)


**Other information**:

No logic has been added, thus no unit tests added