### PR TITLE
feat(material) mat-slide-toggle color support

### DIFF
--- a/src/material/toggle/src/toggle.type.ts
+++ b/src/material/toggle/src/toggle.type.ts
@@ -9,6 +9,7 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
       [id]="id"
       [formControl]="formControl"
       [formlyAttributes]="field"
+      [color]="to.color"
       [tabindex]="to.tabindex || 0">
       {{ to.label }}
     </mat-slide-toggle>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Color property is not forwarded from `templateOptions`.

**What is the new behavior (if this is a feature change)?**
Color property is forwarded from `templateOptions`.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:
Since Slide Toggle supports `color` like many other components, the implementation simply follows other type implementations.