### PR TITLE
feat(material): mat-slider thumbLabel support

### DIFF
--- a/demo/src/app/ui/ui-material/slider/app.component.ts
+++ b/demo/src/app/ui/ui-material/slider/app.component.ts
@@ -17,6 +17,7 @@ export class AppComponent {
       templateOptions: {
         label: 'Slider label',
         // placeholder: 'Slider Placeholder',
+        // thumbLabel: true,
         description: 'Slider Description',
         required: true,
       },

--- a/src/material/slider/src/slider.type.ts
+++ b/src/material/slider/src/slider.type.ts
@@ -12,6 +12,7 @@ import { MatSlider } from '@angular/material/slider';
       [formlyAttributes]="field"
       [tabindex]="to.tabindex || 0"
       [color]="to.color"
+      [thumbLabel]="to.thumbLabel"
       [step]="to.step"
       [max]="to.max"
       [min]="to.min">
@@ -24,6 +25,7 @@ export class FormlySliderTypeComponent extends FieldType {
     templateOptions: {
       hideFieldUnderline: true,
       floatLabel: 'always',
+      thumbLabel: false,
     },
   };
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds support for enabling `thumLabel` in material slider.


**What is the current behavior? (You can also link to an open issue here)**

Step, max, min are supported on sliders through the templateOptions properties.
However, specifying whether the thumLabel is enabled or not is not supported.


**What is the new behavior (if this is a feature change)?**
You can enable the `thumLabel` via the templateOptions.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
