### PR TITLE
fix(core): fix OnPush FieldTypes not being change detected

### DIFF
--- a/src/core/src/lib/services/formly.form.builder.ts
+++ b/src/core/src/lib/services/formly.form.builder.ts
@@ -1,4 +1,4 @@
-import { Injectable, ComponentFactoryResolver, Injector } from '@angular/core';
+import { Injectable, ComponentFactoryResolver, Injector, ChangeDetectorRef } from '@angular/core';
 import { FormGroup, FormArray } from '@angular/forms';
 import { FormlyConfig } from './formly.config';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyFieldConfigCache, FormlyValueChangeEvent, FormlyFormOptionsCache } from '../components/formly.field.config';
@@ -65,7 +65,11 @@ export class FormlyFormBuilder {
     if (!options._markForCheck) {
       options._markForCheck = (field) => {
         if (field._componentRefs) {
-          field._componentRefs.forEach(ref => ref.changeDetectorRef.markForCheck());
+          field._componentRefs.forEach(ref => {
+            // NOTE: we cannot use ref.changeDetectorRef, see https://github.com/ngx-formly/ngx-formly/issues/2191
+            const changeDetectorRef = ref.injector.get(ChangeDetectorRef);
+            changeDetectorRef.markForCheck();
+          });
         }
 
         if (field.fieldGroup) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix OnPush FieldTypes not being change detected on expressionProperties changes.

**What is the current behavior? (You can also link to an open issue here)**
If ChangeDetectionStrategy.OnPush is used in a custom FieldType, then the templateOptions which are generated via expressionProperties, do not result in a changeDetection check.

**What is the new behavior (if this is a feature change)?**
If a expression property changes, the FieldType is change detected properly.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

