### PR TITLE
fix(ionic): allow async options for ion-select

### DIFF
--- a/src/ionic/src/lib/types/select.ts
+++ b/src/ionic/src/lib/types/select.ts
@@ -4,17 +4,19 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'formly-field-ion-select',
   template: `
-    <ion-select
-      [formControl]="formControl"
-      [ionFormlyAttributes]="field"
-      [multiple]="to.multiple"
-      [interface]="to.interface"
-      [okText]="to.okText"
-      [cancelText]="to.cancelText">
-      <ion-select-option *ngFor="let option of to.options | formlySelectOptions:field | async" [value]="option.value">
-        {{ option.label }}
-      </ion-select-option>
-    </ion-select>
+    <ng-container *ngIf="to.options | formlySelectOptions:field | async; let options">
+      <ion-select
+        [formControl]="formControl"
+        [ionFormlyAttributes]="field"
+        [multiple]="to.multiple"
+        [interface]="to.interface"
+        [okText]="to.okText"
+        [cancelText]="to.cancelText">
+        <ion-select-option *ngFor="let option of options" [value]="option.value">
+            {{ option.label }}
+        </ion-select-option>
+      </ion-select>
+    </ng-container>
   `,
   styles: [':host { display: inherit; }'],
 })


### PR DESCRIPTION
there is a bug for ion-select when options are async, wrapping anything in an ng-container should be a workaround for this old bug

https://github.com/ionic-team/ionic/issues/19324