### PR TITLE
feat(json-schema): map 'boolean', 'string', 'number', 'integer', 'enum' types

### DIFF
--- a/demo/src/app/examples/advanced/json-schema/app.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.module.ts
@@ -75,24 +75,6 @@ export function constValidationMessage(err, field: FormlyFieldConfig) {
         { name: 'const', message: constValidationMessage },
       ],
       types: [
-        {
-          name: 'number',
-          extends: 'input',
-          defaultOptions: {
-            templateOptions: {
-              type: 'number',
-            },
-          },
-        },
-        {
-          name: 'integer',
-          extends: 'input',
-          defaultOptions: {
-            templateOptions: {
-              type: 'number',
-            },
-          },
-        },
         { name: 'enum', extends: 'select' },
         { name: 'null', component: NullTypeComponent, wrappers: ['form-field'] },
         { name: 'array', component: ArrayTypeComponent },

--- a/demo/src/app/examples/advanced/json-schema/app.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.module.ts
@@ -94,7 +94,6 @@ export function constValidationMessage(err, field: FormlyFieldConfig) {
             },
           },
         },
-        { name: 'boolean', extends: 'checkbox' },
         { name: 'enum', extends: 'select' },
         { name: 'null', component: NullTypeComponent, wrappers: ['form-field'] },
         { name: 'array', component: ArrayTypeComponent },

--- a/demo/src/app/examples/advanced/json-schema/app.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.module.ts
@@ -75,7 +75,6 @@ export function constValidationMessage(err, field: FormlyFieldConfig) {
         { name: 'const', message: constValidationMessage },
       ],
       types: [
-        { name: 'enum', extends: 'select' },
         { name: 'null', component: NullTypeComponent, wrappers: ['form-field'] },
         { name: 'array', component: ArrayTypeComponent },
         { name: 'object', component: ObjectTypeComponent },

--- a/demo/src/app/examples/advanced/json-schema/app.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.module.ts
@@ -75,7 +75,6 @@ export function constValidationMessage(err, field: FormlyFieldConfig) {
         { name: 'const', message: constValidationMessage },
       ],
       types: [
-        { name: 'string', extends: 'input' },
         {
           name: 'number',
           extends: 'input',

--- a/src/ui/bootstrap/checkbox/src/checkbox.module.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.module.ts
@@ -20,6 +20,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/bootstrap/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.spec.ts
@@ -26,6 +26,23 @@ describe('ui-bootstrap: Checkbox Type', () => {
     });
   });
 
+  it('should render boolean type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'boolean',
+    });
+
+    expect(query('formly-wrapper-form-field')).not.toBeNull();
+
+    const { properties, attributes } = query('input[type="checkbox"]');
+    expect(properties).toMatchObject({ indeterminate: true });
+    expect(attributes).toMatchObject({
+      class: 'custom-control-input',
+      id: 'formly_1_boolean_name_0',
+      type: 'checkbox',
+    });
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/bootstrap/input/src/input.module.ts
+++ b/src/ui/bootstrap/input/src/input.module.ts
@@ -21,6 +21,7 @@ import { FormlyFieldInput } from './input.type';
           component: FormlyFieldInput,
           wrappers: ['form-field'],
         },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/bootstrap/input/src/input.module.ts
+++ b/src/ui/bootstrap/input/src/input.module.ts
@@ -22,6 +22,24 @@ import { FormlyFieldInput } from './input.type';
           wrappers: ['form-field'],
         },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/bootstrap/input/src/input.type.spec.ts
+++ b/src/ui/bootstrap/input/src/input.type.spec.ts
@@ -25,6 +25,22 @@ describe('ui-bootstrap: Input Type', () => {
     });
   });
 
+  it('should render string type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'string',
+    });
+
+    expect(query('formly-wrapper-form-field')).not.toBeNull();
+
+    const { properties, attributes } = query('input[type="text"]');
+    expect(properties).toMatchObject({ type: 'text' });
+    expect(attributes).toMatchObject({
+      class: 'form-control',
+      id: 'formly_1_string_name_0',
+    });
+  });
+
   it('should render number type', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/bootstrap/input/src/input.type.spec.ts
+++ b/src/ui/bootstrap/input/src/input.type.spec.ts
@@ -41,7 +41,7 @@ describe('ui-bootstrap: Input Type', () => {
     });
   });
 
-  it('should render number type', () => {
+  it('should render input[number] type', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -52,6 +52,34 @@ describe('ui-bootstrap: Input Type', () => {
     expect(attributes).toMatchObject({
       class: 'form-control',
       id: 'formly_1_input_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render number type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'number',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      class: 'form-control',
+      id: 'formly_1_number_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render integer type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'integer',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      class: 'form-control',
+      id: 'formly_1_integer_name_0',
       type: 'number',
     });
   });

--- a/src/ui/bootstrap/select/src/select.module.ts
+++ b/src/ui/bootstrap/select/src/select.module.ts
@@ -22,6 +22,7 @@ import { FormlyFieldSelect } from './select.type';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/bootstrap/select/src/select.type.spec.ts
+++ b/src/ui/bootstrap/select/src/select.type.spec.ts
@@ -27,6 +27,23 @@ describe('ui-bootstrap: Select Type', () => {
     expect(queryAll('option')).toHaveLength(3);
   });
 
+  it('should render enum type', () => {
+    const { query, queryAll } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      templateOptions: {
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-form-field')).not.toBeNull();
+    expect(queryAll('option')).toHaveLength(3);
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/ionic/checkbox/src/checkbox.module.ts
+++ b/src/ui/ionic/checkbox/src/checkbox.module.ts
@@ -21,6 +21,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/ionic/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/ionic/checkbox/src/checkbox.type.spec.ts
@@ -22,6 +22,19 @@ describe('ui-ionic: Checkbox Type', () => {
     });
   });
 
+  it('should render boolean type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'boolean',
+    });
+
+    expect(query('formly-wrapper-ion-form-field')).not.toBeNull();
+    const { attributes } = query('ion-checkbox');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_boolean_name_0',
+    });
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/ionic/input/src/input.module.ts
+++ b/src/ui/ionic/input/src/input.module.ts
@@ -21,6 +21,7 @@ import { FormlyFieldInput } from './input.type';
           component: FormlyFieldInput,
           wrappers: ['form-field'],
         },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/ionic/input/src/input.module.ts
+++ b/src/ui/ionic/input/src/input.module.ts
@@ -22,6 +22,24 @@ import { FormlyFieldInput } from './input.type';
           wrappers: ['form-field'],
         },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/ionic/input/src/input.type.spec.ts
+++ b/src/ui/ionic/input/src/input.type.spec.ts
@@ -23,6 +23,20 @@ describe('ui-ionic: Input Type', () => {
     });
   });
 
+  it('should render string type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'string',
+    });
+
+    expect(query('formly-wrapper-ion-form-field')).not.toBeNull();
+
+    const { attributes } = query('ion-input');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_string_name_0',
+    });
+  });
+
   it('should render number type', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/ionic/input/src/input.type.spec.ts
+++ b/src/ui/ionic/input/src/input.type.spec.ts
@@ -37,7 +37,7 @@ describe('ui-ionic: Input Type', () => {
     });
   });
 
-  it('should render number type', () => {
+  it('should render input[number] type', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -47,6 +47,32 @@ describe('ui-ionic: Input Type', () => {
     const { attributes } = query('ion-input[type="number"]');
     expect(attributes).toMatchObject({
       id: 'formly_1_input_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render number type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'number',
+    });
+
+    const { attributes } = query('ion-input[type="number"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_number_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render integer type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'integer',
+    });
+
+    const { attributes } = query('ion-input[type="number"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_integer_name_0',
       type: 'number',
     });
   });

--- a/src/ui/ionic/select/src/select.module.ts
+++ b/src/ui/ionic/select/src/select.module.ts
@@ -24,6 +24,7 @@ import { FormlyFieldSelect } from './select.type';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/ionic/select/src/select.type.spec.ts
+++ b/src/ui/ionic/select/src/select.type.spec.ts
@@ -27,6 +27,23 @@ describe('ui-ionic: Select Type', () => {
     expect(queryAll('ion-select-option')).toHaveLength(3);
   });
 
+  it('should render enum type', () => {
+    const { query, queryAll } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      templateOptions: {
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-ion-form-field')).not.toBeNull();
+    expect(queryAll('ion-select-option')).toHaveLength(3);
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/kendo/checkbox/src/checkbox.module.ts
+++ b/src/ui/kendo/checkbox/src/checkbox.module.ts
@@ -19,6 +19,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/kendo/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/kendo/checkbox/src/checkbox.type.spec.ts
@@ -30,6 +30,27 @@ describe('ui-kendo: Checkbox Type', () => {
     });
   });
 
+  it('should render boolean type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'boolean',
+      templateOptions: {
+        label: 'Name',
+        required: true,
+      },
+    });
+
+    expect(query('formly-wrapper-kendo-form-field')).not.toBeNull();
+    expect(query('label').nativeElement.textContent).toEqual(' Name *');
+
+    const { attributes } = query('input[type="checkbox"]');
+    expect(attributes).toMatchObject({
+      class: 'k-checkbox',
+      id: 'formly_1_boolean_name_0',
+      type: 'checkbox',
+    });
+  });
+
   it('should add "k-state-invalid" class on invalid', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/kendo/input/src/input.module.ts
+++ b/src/ui/kendo/input/src/input.module.ts
@@ -20,6 +20,24 @@ import { FormlyFieldInput } from './input.type';
           wrappers: ['form-field'],
         },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/kendo/input/src/input.module.ts
+++ b/src/ui/kendo/input/src/input.module.ts
@@ -19,6 +19,7 @@ import { FormlyFieldInput } from './input.type';
           component: FormlyFieldInput,
           wrappers: ['form-field'],
         },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/kendo/input/src/input.type.spec.ts
+++ b/src/ui/kendo/input/src/input.type.spec.ts
@@ -41,7 +41,7 @@ describe('ui-kendo: Input Type', () => {
     });
   });
 
-  it('should render number type', () => {
+  it('should render input[number] type', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -52,6 +52,34 @@ describe('ui-kendo: Input Type', () => {
     expect(attributes).toMatchObject({
       class: 'k-textbox',
       id: 'formly_1_input_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render number type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'number',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      class: 'k-textbox',
+      id: 'formly_1_number_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render integer type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'integer',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      class: 'k-textbox',
+      id: 'formly_1_integer_name_0',
       type: 'number',
     });
   });

--- a/src/ui/kendo/input/src/input.type.spec.ts
+++ b/src/ui/kendo/input/src/input.type.spec.ts
@@ -25,6 +25,22 @@ describe('ui-kendo: Input Type', () => {
     });
   });
 
+  it('should render string type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'string',
+    });
+
+    expect(query('formly-wrapper-kendo-form-field')).not.toBeNull();
+
+    const { properties, attributes } = query('input[type="text"]');
+    expect(properties).toMatchObject({ type: 'text' });
+    expect(attributes).toMatchObject({
+      class: 'k-textbox',
+      id: 'formly_1_string_name_0',
+    });
+  });
+
   it('should render number type', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/kendo/select/src/select.module.ts
+++ b/src/ui/kendo/select/src/select.module.ts
@@ -24,6 +24,7 @@ import { FormlyFieldSelect } from './select.type';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/kendo/select/src/select.type.spec.ts
+++ b/src/ui/kendo/select/src/select.type.spec.ts
@@ -37,6 +37,26 @@ describe('ui-kendo: Select Type', () => {
     expect(document.querySelectorAll('.k-item')).toHaveLength(3);
   });
 
+  it('should render enum type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      templateOptions: {
+        label: 'Select',
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-kendo-form-field')).not.toBeNull();
+
+    query('kendo-dropdownlist .k-dropdown-wrap').triggerEventHandler('click', {});
+    expect(document.querySelectorAll('.k-item')).toHaveLength(3);
+  });
+
   it('should bind control value on change', () => {
     const { query, field } = renderComponent({
       key: 'name',

--- a/src/ui/material/checkbox/src/checkbox.module.ts
+++ b/src/ui/material/checkbox/src/checkbox.module.ts
@@ -24,6 +24,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/material/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/material/checkbox/src/checkbox.type.spec.ts
@@ -25,6 +25,21 @@ describe('ui-material: Checkbox Type', () => {
     });
   });
 
+  it('should render boolean type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'boolean',
+    });
+
+    expect(query('formly-wrapper-mat-form-field')).not.toBeNull();
+
+    const { attributes } = query('mat-checkbox');
+    expect(attributes).toMatchObject({ id: 'formly_1_boolean_name_0' });
+    expect(query('input[type="checkbox"]').properties).toMatchObject({
+      indeterminate: true,
+    });
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/material/input/src/input.module.ts
+++ b/src/ui/material/input/src/input.module.ts
@@ -23,6 +23,7 @@ import { FormlyFieldInput } from './input.type';
           component: FormlyFieldInput,
           wrappers: ['form-field'],
         },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/material/input/src/input.module.ts
+++ b/src/ui/material/input/src/input.module.ts
@@ -24,6 +24,24 @@ import { FormlyFieldInput } from './input.type';
           wrappers: ['form-field'],
         },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/material/input/src/input.type.spec.ts
+++ b/src/ui/material/input/src/input.type.spec.ts
@@ -38,7 +38,7 @@ describe('ui-material: Input Type', () => {
     });
   });
 
-  it('should render number type', () => {
+  it('should render input[number] type', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -48,6 +48,30 @@ describe('ui-material: Input Type', () => {
     const { attributes } = query('input[type="number"]');
     expect(attributes).toMatchObject({
       id: 'formly_1_input_name_0',
+    });
+  });
+
+  it('should render number type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'number',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_number_name_0',
+    });
+  });
+
+  it('should render integer type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'integer',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_integer_name_0',
     });
   });
 

--- a/src/ui/material/input/src/input.type.spec.ts
+++ b/src/ui/material/input/src/input.type.spec.ts
@@ -24,6 +24,20 @@ describe('ui-material: Input Type', () => {
     });
   });
 
+  it('should render string type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'string',
+    });
+
+    expect(query('formly-wrapper-mat-form-field')).not.toBeNull();
+
+    const { attributes } = query('input[type="text"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_string_name_0',
+    });
+  });
+
   it('should render number type', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/material/select/src/select.module.ts
+++ b/src/ui/material/select/src/select.module.ts
@@ -27,6 +27,7 @@ import { MatPseudoCheckboxModule } from '@angular/material/core';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/material/select/src/select.type.spec.ts
+++ b/src/ui/material/select/src/select.type.spec.ts
@@ -34,6 +34,27 @@ describe('ui-material: Formly Field Select Component', () => {
     expect(queryAll('mat-option')).toHaveLength(3);
   });
 
+  it('should render enum type', () => {
+    const { query, queryAll, detectChanges } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      templateOptions: {
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-mat-form-field')).not.toBeNull();
+
+    query('.mat-select-trigger').triggerEventHandler('click', {});
+    detectChanges();
+
+    expect(queryAll('mat-option')).toHaveLength(3);
+  });
+
   it('should bind control value on change', () => {
     const { query, queryAll, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/nativescript/checkbox/src/checkbox.module.ts
+++ b/src/ui/nativescript/checkbox/src/checkbox.module.ts
@@ -22,6 +22,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/nativescript/select/src/select.module.ts
+++ b/src/ui/nativescript/select/src/select.module.ts
@@ -24,6 +24,7 @@ import { FormlyFieldSelect } from './select.type';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/nativescript/text-field/src/text-field.module.ts
+++ b/src/ui/nativescript/text-field/src/text-field.module.ts
@@ -24,6 +24,24 @@ import { FormlyFieldText } from './text-field.type';
         },
         { name: 'input', extends: 'text-field' },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/nativescript/text-field/src/text-field.module.ts
+++ b/src/ui/nativescript/text-field/src/text-field.module.ts
@@ -23,6 +23,7 @@ import { FormlyFieldText } from './text-field.type';
           wrappers: ['form-field'],
         },
         { name: 'input', extends: 'text-field' },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/ng-zorro-antd/checkbox/src/checkbox.module.ts
+++ b/src/ui/ng-zorro-antd/checkbox/src/checkbox.module.ts
@@ -24,6 +24,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/ng-zorro-antd/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/ng-zorro-antd/checkbox/src/checkbox.type.spec.ts
@@ -26,6 +26,22 @@ describe('ui-ng-zorro-antd: Checkbox Type', () => {
     });
   });
 
+  it('should render boolean type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'boolean',
+    });
+
+    expect(query('formly-wrapper-nz-form-field')).not.toBeNull();
+
+    expect(query('.ant-checkbox-indeterminate')).not.toBeNull();
+    expect(query('input[type="checkbox"]')).not.toBeNull();
+    const { attributes } = query('label[nz-checkbox]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_boolean_name_0',
+    });
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/ng-zorro-antd/input/src/input.module.ts
+++ b/src/ui/ng-zorro-antd/input/src/input.module.ts
@@ -25,6 +25,7 @@ import { FormlyFieldInput } from './input.type';
           component: FormlyFieldInput,
           wrappers: ['form-field'],
         },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/ng-zorro-antd/input/src/input.module.ts
+++ b/src/ui/ng-zorro-antd/input/src/input.module.ts
@@ -26,6 +26,24 @@ import { FormlyFieldInput } from './input.type';
           wrappers: ['form-field'],
         },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/ng-zorro-antd/input/src/input.type.spec.ts
+++ b/src/ui/ng-zorro-antd/input/src/input.type.spec.ts
@@ -40,7 +40,7 @@ describe('ui-ng-zorro-antd: Input Type', () => {
     });
   });
 
-  it('should render number type', () => {
+  it('should render input[number] type', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -50,6 +50,30 @@ describe('ui-ng-zorro-antd: Input Type', () => {
     const { attributes } = query('nz-input-number');
     expect(attributes).toMatchObject({
       id: 'formly_1_input_name_0',
+    });
+  });
+
+  it('should render number type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'number',
+    });
+
+    const { attributes } = query('nz-input-number');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_number_name_0',
+    });
+  });
+
+  it('should render integer type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'integer',
+    });
+
+    const { attributes } = query('nz-input-number');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_integer_name_0',
     });
   });
 

--- a/src/ui/ng-zorro-antd/input/src/input.type.spec.ts
+++ b/src/ui/ng-zorro-antd/input/src/input.type.spec.ts
@@ -25,6 +25,21 @@ describe('ui-ng-zorro-antd: Input Type', () => {
     });
   });
 
+  it('should render string type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'string',
+    });
+
+    expect(query('formly-wrapper-nz-form-field')).not.toBeNull();
+
+    const { properties, attributes } = query('input[type="text"]');
+    expect(properties).toMatchObject({ type: 'text' });
+    expect(attributes).toMatchObject({
+      id: 'formly_1_string_name_0',
+    });
+  });
+
   it('should render number type', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/ng-zorro-antd/select/src/select.module.ts
+++ b/src/ui/ng-zorro-antd/select/src/select.module.ts
@@ -25,6 +25,7 @@ import { FormlyFieldSelect } from './select.type';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/ng-zorro-antd/select/src/select.type.spec.ts
+++ b/src/ui/ng-zorro-antd/select/src/select.type.spec.ts
@@ -31,6 +31,27 @@ describe('ui-ng-zorro-antd: Select Type', () => {
     expect(queryAll('li[nz-option-li]')).toHaveLength(3);
   });
 
+  it('should render enum type', () => {
+    const { query, queryAll, detectChanges } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      templateOptions: {
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-nz-form-field')).not.toBeNull();
+
+    query('nz-select').triggerEventHandler('click', {});
+    detectChanges();
+
+    expect(queryAll('li[nz-option-li]')).toHaveLength(3);
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/primeng/checkbox/src/checkbox.module.ts
+++ b/src/ui/primeng/checkbox/src/checkbox.module.ts
@@ -21,6 +21,10 @@ import { FormlyFieldCheckbox } from './checkbox.type';
           component: FormlyFieldCheckbox,
           wrappers: ['form-field'],
         },
+        {
+          name: 'boolean',
+          extends: 'checkbox',
+        },
       ],
     }),
   ],

--- a/src/ui/primeng/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/primeng/checkbox/src/checkbox.type.spec.ts
@@ -24,6 +24,21 @@ describe('ui-primeng: Checkbox Type', () => {
     });
   });
 
+  it('should render boolean type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'boolean',
+    });
+
+    expect(query('formly-wrapper-primeng-form-field')).not.toBeNull();
+
+    const { attributes } = query('p-checkbox');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_boolean_name_0',
+      binary: 'true',
+    });
+  });
+
   it('should bind control value on change', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/primeng/input/src/input.module.ts
+++ b/src/ui/primeng/input/src/input.module.ts
@@ -21,6 +21,7 @@ import { FormlyFieldInput } from './input.type';
           component: FormlyFieldInput,
           wrappers: ['form-field'],
         },
+        { name: 'string', extends: 'input' },
       ],
     }),
   ],

--- a/src/ui/primeng/input/src/input.module.ts
+++ b/src/ui/primeng/input/src/input.module.ts
@@ -22,6 +22,24 @@ import { FormlyFieldInput } from './input.type';
           wrappers: ['form-field'],
         },
         { name: 'string', extends: 'input' },
+        {
+          name: 'number',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
+        {
+          name: 'integer',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'number',
+            },
+          },
+        },
       ],
     }),
   ],

--- a/src/ui/primeng/input/src/input.type.spec.ts
+++ b/src/ui/primeng/input/src/input.type.spec.ts
@@ -39,7 +39,7 @@ describe('ui-primeng: Input Type', () => {
     });
   });
 
-  it('should render number type', () => {
+  it('should render input[number] type', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -49,6 +49,32 @@ describe('ui-primeng: Input Type', () => {
     const { attributes } = query('input[type="number"]');
     expect(attributes).toMatchObject({
       id: 'formly_1_input_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render number type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'number',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_number_name_0',
+      type: 'number',
+    });
+  });
+
+  it('should render integer type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'integer',
+    });
+
+    const { attributes } = query('input[type="number"]');
+    expect(attributes).toMatchObject({
+      id: 'formly_1_integer_name_0',
       type: 'number',
     });
   });

--- a/src/ui/primeng/input/src/input.type.spec.ts
+++ b/src/ui/primeng/input/src/input.type.spec.ts
@@ -24,6 +24,21 @@ describe('ui-primeng: Input Type', () => {
     });
   });
 
+  it('should render string type', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'string',
+    });
+
+    expect(query('formly-wrapper-primeng-form-field')).not.toBeNull();
+
+    const { properties, attributes } = query('input[type="text"]');
+    expect(properties).toMatchObject({ type: 'text' });
+    expect(attributes).toMatchObject({
+      id: 'formly_1_string_name_0',
+    });
+  });
+
   it('should render number type', () => {
     const { query } = renderComponent({
       key: 'name',

--- a/src/ui/primeng/select/src/select.module.ts
+++ b/src/ui/primeng/select/src/select.module.ts
@@ -24,6 +24,7 @@ import { FormlyFieldSelect } from './select.type';
           component: FormlyFieldSelect,
           wrappers: ['form-field'],
         },
+        { name: 'enum', extends: 'select' },
       ],
     }),
   ],

--- a/src/ui/primeng/select/src/select.type.spec.ts
+++ b/src/ui/primeng/select/src/select.type.spec.ts
@@ -31,6 +31,26 @@ describe('ui-primeng: Select Type', () => {
     expect(queryAll('p-dropdownItem')).toHaveLength(3);
   });
 
+  it('should render enum type', () => {
+    const { query, queryAll } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      templateOptions: {
+        label: 'Select',
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-primeng-form-field')).not.toBeNull();
+
+    query('p-dropdown div').triggerEventHandler('click', { target: {} });
+    expect(queryAll('p-dropdownItem')).toHaveLength(3);
+  });
+
   it('should bind control value on change', () => {
     const { query, queryAll, field } = renderComponent({
       key: 'name',


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature.

**What is the current behavior? (You can also link to an open issue here)**

Currently we have to add custom field type mappings for our json types.

**What is the new behavior (if this is a feature change)?**

We add the field types mappings to each of the Formly UI libraries.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:

I've added tests to all the types that had a test (all ui libs except for NativeScript). 

Next to that, taking them away from the demo app's app module makes sure the demos keep working as expected.