### PR TITLE
feat(json-schema): move 'null' type to @formly/core

### DIFF
--- a/demo/src/app/examples/advanced/json-schema/app.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.module.ts
@@ -75,7 +75,6 @@ export function constValidationMessage(err, field: FormlyFieldConfig) {
         { name: 'const', message: constValidationMessage },
       ],
       types: [
-        { name: 'null', component: NullTypeComponent, wrappers: ['form-field'] },
         { name: 'array', component: ArrayTypeComponent },
         { name: 'object', component: ObjectTypeComponent },
         { name: 'multischema', component: MultiSchemaTypeComponent },

--- a/src/core/src/lib/core.module.ts
+++ b/src/core/src/lib/core.module.ts
@@ -8,6 +8,7 @@ import { FormlyFormBuilder } from './services/formly.builder';
 import { FormlyGroup } from './templates/formly.group';
 import { FormlyValidationMessage } from './templates/formly.validation-message';
 import { FormlyTemplateType } from './templates/field-template.type';
+import { NullTypeComponent } from './templates/null.type';
 
 import { FieldExpressionExtension } from './extensions/field-expression/field-expression';
 import { FieldValidationExtension } from './extensions/field-validation/field-validation';
@@ -20,6 +21,7 @@ export function defaultFormlyConfig(config: FormlyConfig): ConfigOption {
     types: [
       { name: 'formly-group', component: FormlyGroup },
       { name: 'formly-template', component: FormlyTemplateType },
+      { name: 'null', component: NullTypeComponent },
     ],
     extensions: [
       { name: 'core', extension: new CoreExtension(config) },
@@ -31,8 +33,16 @@ export function defaultFormlyConfig(config: FormlyConfig): ConfigOption {
 }
 
 @NgModule({
-  declarations: [FormlyForm, FormlyField, FormlyAttributes, FormlyGroup, FormlyValidationMessage, FormlyTemplateType],
-  entryComponents: [FormlyGroup, FormlyTemplateType],
+  declarations: [
+    FormlyForm,
+    FormlyField,
+    FormlyAttributes,
+    FormlyGroup,
+    FormlyValidationMessage,
+    FormlyTemplateType,
+    NullTypeComponent,
+  ],
+  entryComponents: [FormlyGroup, FormlyTemplateType, NullTypeComponent],
   exports: [FormlyForm, FormlyField, FormlyAttributes, FormlyGroup, FormlyValidationMessage],
   imports: [CommonModule],
 })

--- a/src/core/src/lib/templates/null.spec.ts
+++ b/src/core/src/lib/templates/null.spec.ts
@@ -1,0 +1,12 @@
+import { createFormlyFieldComponent as renderComponent } from '@ngx-formly/core/testing';
+
+describe('Null Field Type', () => {
+  it('should render null', () => {
+    const { query, queryAll } = renderComponent({
+      type: 'null',
+    });
+
+    expect(query('null')).toBeNull();
+    expect(queryAll('formly')).toHaveLength(0);
+  });
+});

--- a/src/core/src/lib/templates/null.type.ts
+++ b/src/core/src/lib/templates/null.type.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+import { FieldType } from './field.type';
+
+@Component({
+  selector: 'formly-null-type',
+  template: '',
+})
+export class NullTypeComponent extends FieldType {}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**

Null type for json-schema needs to be implemented manually.


**What is the new behavior (if this is a feature change)?**

Null type for json-schema is added to @formly/core


**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:

I think it makes most sense to add the `null` type to core, but open for other suggestions.

I had to get rid of the `form-field` wrapper, not sure if that's an issues. 

@aitboudad what do you think?