### PR TITLE
Use hideLabel property

### DIFF
--- a/src/ui/bootstrap/checkbox/src/checkbox.type.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.ts
@@ -24,6 +24,7 @@ import { FieldType } from '@ngx-formly/core';
         [formlyAttributes]="field"
       />
       <label
+        *ngIf="!to.hideLabel"  
         [for]="id"
         [class.form-check-label]="to.formCheck.indexOf('custom') === -1"
         [class.custom-control-label]="to.formCheck.indexOf('custom') === 0"


### PR DESCRIPTION
hideLabel is unused and checbox type cannot be configured for common horizontal wrapper with non duplicated labels