### PR TITLE
feat(bootstrap): use hideLabel for checbox

### DIFF
--- a/src/ui/bootstrap/checkbox/src/checkbox.type.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.ts
@@ -24,6 +24,7 @@ import { FieldType } from '@ngx-formly/core';
         [formlyAttributes]="field"
       />
       <label
+        *ngIf="!to.hideLabel" 
         [for]="id"
         [class.form-check-label]="to.formCheck.indexOf('custom') === -1"
         [class.custom-control-label]="to.formCheck.indexOf('custom') === 0"
@@ -38,7 +39,7 @@ export class FormlyFieldCheckbox extends FieldType {
   defaultOptions = {
     templateOptions: {
       indeterminate: true,
-      hideLabel: true,
+      hideLabel: false,
       formCheck: 'custom', // 'custom' | 'custom-inline' | 'custom-switch' | 'stacked' | 'inline'
     },
   };


### PR DESCRIPTION
hideLabel is unused and checbox type cannot be configured for common horizontal wrapper with non duplicated labels