### PR TITLE
fix(material): removed double tag closing in datepicker type

### DIFF
--- a/src/ui/material/datepicker/src/datepicker.type.ts
+++ b/src/ui/material/datepicker/src/datepicker.type.ts
@@ -23,7 +23,6 @@ import { MatDatepickerInput } from '@angular/material/datepicker';
       (dateInput)="to.datepickerOptions.dateInput(field, $event)"
       (dateChange)="to.datepickerOptions.dateChange(field, $event)"
     />
-    />
     <ng-template #datepickerToggle>
       <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
     </ng-template>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix. Picker is not visible.


**What is the current behavior? (You can also link to an open issue here)**
Picker opens with empty content.


**What is the new behavior (if this is a feature change)?**
Picker html template is correct.


**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
