### PR TITLE
chore(guide): fixed template code in Introduction

### DIFF
--- a/demo/src/app/guides/introduction.md
+++ b/demo/src/app/guides/introduction.md
@@ -44,7 +44,7 @@ The forRoot() call is required at the application's root level. The forRoot() me
 2. add `<formly-form>` inside the `form` tag to your `AppComponent` template:
 
 ```html
-<form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+<form [formGroup]="form" (ngSubmit)="onSubmit()">
   <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>
   <button type="submit" class="btn btn-default">Submit</button>
 </form>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This is docs update


**What is the current behavior? (You can also link to an open issue here)**
Ffter copy-pasting introduction code to IDE, the compiler throws error `Expected 0 arguments, but got 1` in `<form [formGroup]="form" (ngSubmit)="onSubmit(model)">`


**What is the new behavior (if this is a feature change)?**
after copy-pasting introduction code to IDE, the compiler successfully compiles the template


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [n/a] A unit test has been written for this change.
- [n/a] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [n/a] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
![image](https://user-images.githubusercontent.com/23387542/88567141-12614580-d005-11ea-85cd-cd969a0dfc1d.png)


**Other information**:
