### PR TITLE
docs(introduction.md): remove model input from onSubmit function in HTML

### DIFF
--- a/demo/src/app/guides/introduction.md
+++ b/demo/src/app/guides/introduction.md
@@ -44,7 +44,7 @@ The forRoot() call is required at the application's root level. The forRoot() me
 2. add `<formly-form>` inside the `form` tag to your `AppComponent` template:
 
 ```html
-<form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+<form [formGroup]="form" (ngSubmit)="onSubmit()">
   <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>
   <button type="submit" class="btn btn-default">Submit</button>
 </form>
@@ -68,7 +68,7 @@ import {FormlyFieldConfig} from '@ngx-formly/core';
 @Component({
   selector: 'app',
   template: `
-    <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>
       <button type="submit" class="btn btn-default">Submit</button>
     </form>
@@ -95,7 +95,7 @@ export class AppComponent {
 }
 ```
 
-That's it, the above example will render an email input 
+That's it, the above example will render an email input
 that is marked required and filled with 'email@gmail.com' value.
 
 <div align="center">


### PR DESCRIPTION
Remove model input from HTML to be able to copy/paste the example without issues when getting started

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs


**What is the current behavior? (You can also link to an open issue here)**
Introduction example does not work when copy pasted because of an extra attribute being passed in to the onSubmit function in the html


**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
![image](https://user-images.githubusercontent.com/33256364/89093199-bdfbf400-d37d-11ea-97d7-ce652cfaf760.png)

![image](https://user-images.githubusercontent.com/33256364/89093161-a45aac80-d37d-11ea-8ea4-d6693b34526f.png)



**Other information**:
