### PR TITLE
fix(material): remove empty mat-prefix and mat-suffix

### DIFF
--- a/src/material/form-field/src/form-field.wrapper.ts
+++ b/src/material/form-field/src/form-field.wrapper.ts
@@ -28,11 +28,11 @@ interface MatFormlyFieldConfig extends FormlyFieldConfig {
         <span *ngIf="to.required && to.hideRequiredMarker !== true" class="mat-form-field-required-marker">*</span>
       </mat-label>
 
-      <ng-container matPrefix>
+      <ng-container matPrefix *ngIf="to.prefix || formlyField._matprefix">
         <ng-container *ngTemplateOutlet="to.prefix ? to.prefix : formlyField._matprefix"></ng-container>
       </ng-container>
 
-      <ng-container matSuffix>
+      <ng-container matSuffix *ngIf="to.suffix || formlyField._matsuffix">
         <ng-container *ngTemplateOutlet="to.suffix ? to.suffix : formlyField._matsuffix"></ng-container>
       </ng-container>
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/ngx-formly/ngx-formly/issues/2443

**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
