### PR TITLE
 fix(core): rely on internal model when model input is empty

### DIFF
--- a/src/core/src/lib/components/formly.form.ts
+++ b/src/core/src/lib/components/formly.form.ts
@@ -28,7 +28,13 @@ export class FormlyForm implements DoCheck, OnChanges, OnDestroy {
 
   @Input()
   set model(model: any) { this._model = this.immutable ? clone(model) : model; }
-  get model() { return this._model || {}; }
+  get model() {
+    if (!this._model) {
+      this._model = {};
+    }
+
+    return this._model;
+  }
 
   @Input()
   set fields(fields: FormlyFieldConfig[]) { this._fields = this.immutable ? clone(fields) : fields; }

--- a/src/core/src/lib/templates/field-array.type.spec.ts
+++ b/src/core/src/lib/templates/field-array.type.spec.ts
@@ -237,7 +237,6 @@ describe('Array Field Type', () => {
     subscription.unsubscribe();
   });
 
-
   it('should share formControl when field key is duplicated', () => {
     app.fields = [
       {
@@ -282,6 +281,23 @@ describe('Array Field Type', () => {
 
     expect(form.at(1)).not.toEqual(form.at(0));
     expect(form.at(1).value).toEqual(null);
+  });
+
+  // https://github.com/ngx-formly/ngx-formly/issues/2493
+  it('should add field when model is null', () => {
+    app.model = null;
+    app.fields = [{
+      key: 'array',
+      type: 'array',
+    }];
+
+    const fixture = createFormlyTestComponent();
+
+    fixture.nativeElement.querySelector('#add').click();
+    fixture.detectChanges();
+
+    expect(app.fields[0].fieldGroup.length).toEqual(1);
+    expect(app.form.value).toEqual({ array: [null] });
   });
 });
 


### PR DESCRIPTION
fix #2493