### PR TITLE
docs(demo): make the 'focus' work in the Introduction Example

### DIFF
--- a/demo/src/app/examples/introduction/app.component.ts
+++ b/demo/src/app/examples/introduction/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent {
         description: '',
       },
       expressionProperties: {
-        'templateOptions.focus': 'formState.awesomeIsForced',
+        focus: 'formState.awesomeIsForced',
         'templateOptions.description': (model, formState) => {
           if (formState.awesomeIsForced) {
             return 'And look! This field magically got focus!';


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix in the documentation


**What is the current behavior?**
The 'focus' feature does not work in the introduction example: https://stackblitz.com/angular/lvmnpkeaaqb and the _And look! This field magically got focus!_ description does not make any sense because of it.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build.
- [x] My code has been linted.