### PR TITLE
feat(bootstrap): add custom classes to form-field wrapper

### DIFF
--- a/src/ui/bootstrap/form-field/src/form-field.wrapper.spec.ts
+++ b/src/ui/bootstrap/form-field/src/form-field.wrapper.spec.ts
@@ -27,7 +27,7 @@ describe('ui-bootstrap: FormField Wrapper', () => {
     expect(query('small.form-text').nativeElement.textContent).toEqual('Name description');
   });
 
-  it('should show error message', () => {
+  it('should show add custom form group classes', () => {
     const { query } = renderComponent({
       key: 'name',
       wrappers: ['form-field'],
@@ -39,6 +39,20 @@ describe('ui-bootstrap: FormField Wrapper', () => {
     });
 
     expect(query('formly-validation-message')).not.toBeNull();
+  });
+
+  it('should add custom classes', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      wrappers: ['form-field'],
+      validation: { show: true },
+      templateOptions: {
+        label: 'Name',
+        customFormGroupClasses: 'test1 test2',
+      },
+    });
+
+    expect(query('div.form-group').nativeElement.classList).toContainAllValues(['test1', 'test2', 'form-group']);
   });
 
   it('should hide required marker', () => {

--- a/src/ui/bootstrap/form-field/src/form-field.wrapper.spec.ts
+++ b/src/ui/bootstrap/form-field/src/form-field.wrapper.spec.ts
@@ -27,7 +27,7 @@ describe('ui-bootstrap: FormField Wrapper', () => {
     expect(query('small.form-text').nativeElement.textContent).toEqual('Name description');
   });
 
-  it('should show add custom form group classes', () => {
+  it('should show error message', () => {
     const { query } = renderComponent({
       key: 'name',
       wrappers: ['form-field'],

--- a/src/ui/bootstrap/form-field/src/form-field.wrapper.ts
+++ b/src/ui/bootstrap/form-field/src/form-field.wrapper.ts
@@ -4,7 +4,7 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
   selector: 'formly-wrapper-form-field',
   template: `
-    <div class="form-group" [class.has-error]="showError">
+    <div class="form-group" [class.has-error]="showError" [ngClass]="to.customFormGroupClasses">
       <label *ngIf="to.label && to.hideLabel !== true" [attr.for]="id">
         {{ to.label }}
         <span *ngIf="to.required && to.hideRequiredMarker !== true">*</span>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Small feature that allows adding custom CSS classes to the bootstrap form-field wrapper


**What is the current behavior? (You can also link to an open issue here)**
The form-field wrapper does not allow adding additional css classes to form-group div.


**What is the new behavior (if this is a feature change)?**
Ability to specify additional CSS classes in template options to be applied to the form-group div.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
