### PR TITLE
docs(demo): remove stock identifier label in two examples

### DIFF
--- a/demo/src/app/examples/advanced/datatable-integration/app.component.ts
+++ b/demo/src/app/examples/advanced/datatable-integration/app.component.ts
@@ -68,9 +68,6 @@ export class AppComponent {
           {
             type: 'input',
             key: 'stockIdentifier',
-            templateOptions: {
-              label: 'Stock Identifier:',
-            },
           },
         ],
       },

--- a/demo/src/app/examples/advanced/grid-integration/app.component.ts
+++ b/demo/src/app/examples/advanced/grid-integration/app.component.ts
@@ -123,9 +123,6 @@ export class AppComponent {
           {
             type: 'input',
             key: 'stockIdentifier',
-            templateOptions: {
-              label: 'Stock Identifier:',
-            },
           },
         ],
       },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix on two example pages

**What is the current behavior? (You can also link to an open issue here)**

Currently, the example pages for ag-grid integration and ngx-datatable integration include "Stock Identifier" labels that mess up formatting for the ngx-datatable  example and make the ag-grid example very hard to use:

![grid-integration-bug](https://user-images.githubusercontent.com/34165455/101187073-2cb2cc00-3654-11eb-92b0-b8134d482a15.png)
![datatable-bug](https://user-images.githubusercontent.com/34165455/101187160-4b18c780-3654-11eb-94c8-63b4f59e4238.png)

**What is the new behavior (if this is a feature change)?**
I removed the labels to align the examples and make them look / work better.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

No tests apply to this PR

**Screenshots after changes**

![image](https://user-images.githubusercontent.com/34165455/101187475-b793c680-3654-11eb-9f9a-2bc36a574ee9.png)
![image](https://user-images.githubusercontent.com/34165455/101187630-e742ce80-3654-11eb-965d-0c9ad5a427d7.png)


**Other information**:
This was such a small fix that I decided not to open an issue.