### PR TITLE
docs(demo): add missing icons for primeng components

### DIFF
--- a/demo/src/app/ui/ui-primeng/app.component.scss
+++ b/demo/src/app/ui/ui-primeng/app.component.scss
@@ -1,2 +1,3 @@
 @import '~primeng/resources/primeng.min.css';
 @import '~primeng/resources/themes/nova-light/theme.css';
+@import 'primeicons/primeicons.css';

--- a/demo/src/styles.scss
+++ b/demo/src/styles.scss
@@ -13,13 +13,14 @@
 @import '~bootstrap/scss/custom-forms';
 @import '~bootstrap/scss/card';
 
-@import "primeicons/primeicons.css";
-
 legend {
   margin-bottom: 20px;
   font-size: 21px;
   border-bottom: 1px solid #e5e5e5;
 }
+
+// primeicons for primeng
+@import "primeicons/primeicons.css";
 
 // highlight.js
 @import '~highlight.js/styles/github.css';

--- a/demo/src/styles.scss
+++ b/demo/src/styles.scss
@@ -19,9 +19,6 @@ legend {
   border-bottom: 1px solid #e5e5e5;
 }
 
-// primeicons for primeng
-@import "primeicons/primeicons.css";
-
 // highlight.js
 @import '~highlight.js/styles/github.css';
 

--- a/demo/src/styles.scss
+++ b/demo/src/styles.scss
@@ -13,6 +13,8 @@
 @import '~bootstrap/scss/custom-forms';
 @import '~bootstrap/scss/card';
 
+@import "primeicons/primeicons.css";
+
 legend {
   margin-bottom: 20px;
   font-size: 21px;

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "express": "^4.15.2",
     "ng-zorro-antd": "^9.2.1",
     "primeng": "^9.1.0",
+    "primeicons": "^2.0.0",
     "rxjs": "^6.5.5",
     "tns-core-modules": "^6.5.7",
     "tslib": "^2.0.0",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix the missing icons on PrimeNG Demo.

**What is the current behavior? (You can also link to an open issue here)**
The checkbox on PrimeNG Demo doesn't show the tick mark.

**What is the new behavior (if this is a feature change)?**
The checkbox on PrimeNG Demo shows the tick mark.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Please provide a screenshot of this feature before and after your code changes, if applicable.**

Before screenshot:
![image](https://user-images.githubusercontent.com/13326475/101267193-e8e3c380-3734-11eb-81df-bcfb6ac36f4e.png)


After screenshot:
![image](https://user-images.githubusercontent.com/13326475/101267202-fef18400-3734-11eb-99b4-3646cecf534e.png)

