### PR TITLE
feat(core): add v6 migration guide

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -19,3 +19,24 @@ UPGRADE FROM 5.0 to 6.0
   ```
 
 - BREAKING CHANGE: The initial value of the created FormControl has been changed from `null` to `undefined` to match the field model value. ([#1917](https://github.com/ngx-formly/ngx-formly/pull/1917))
+  
+  before:
+  ```ts
+  let fields: FormlyFieldConfig[] = [
+    {
+      key: 'text',
+      type: 'input'
+    }
+  ]
+  ```
+  
+  after:
+  ```ts
+  let fields: FormlyFieldConfig[] = [
+    {
+      key: 'text',
+      type: 'input',
+      defaultValue: null
+    }
+  ]
+  ```

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -4,6 +4,19 @@ UPGRADE FROM 5.0 to 6.0
 
 @ngx-formly/core
 ----------------
-- BREAKING CHANGE: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901))
+- BREAKING CHANGE: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901))  
+  ```js
+  FormlyModule.forRoot({
+    types: [
+      {
+        extends: 'formly-group',
+        defaultOptions: {
+          defaultValue: {}
+        }
+      }
+    ],
+  })
+  ```
+
 - BREAKING CHANGE: The initial value of the created FormControl has been changed from `null` to `undefined` to match the field model value. ([#1917](https://github.com/ngx-formly/ngx-formly/pull/1917))
 - BREAKING CHANGE: `fieldChanges` will emit on every field change

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -4,8 +4,13 @@ UPGRADE FROM 5.0 to 6.0
 
 @ngx-formly/core
 ----------------
-- BREAKING CHANGE: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901))  
-  ```js
+- BREAKING CHANGE: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901)
+
+  before: 
+  If no default value is set the `defaultValue` for formlyGroup is `{}` and for fieldArray `[]`
+  
+  after:
+  ```ts
   FormlyModule.forRoot({
     types: [
       {

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -19,4 +19,3 @@ UPGRADE FROM 5.0 to 6.0
   ```
 
 - BREAKING CHANGE: The initial value of the created FormControl has been changed from `null` to `undefined` to match the field model value. ([#1917](https://github.com/ngx-formly/ngx-formly/pull/1917))
-- BREAKING CHANGE: `fieldChanges` will emit on every field change

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -1,0 +1,9 @@
+UPGRADE FROM 5.0 to 6.0
+=======================
+- BREAKING CHANGE: Formly v6 now requires Angular Version >= 11
+
+@ngx-formly/core
+----------------
+- BREAKING CHANGE: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901))
+- BREAKING CHANGE: The initial value of the created FormControl has been changed from `null` to `undefined` to match the field model value. ([#1917](https://github.com/ngx-formly/ngx-formly/pull/1917))
+- BREAKING CHANGE: `fieldChanges` will emit on every field change

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -1,15 +1,15 @@
 UPGRADE FROM 5.0 to 6.0
 =======================
-- BREAKING CHANGE: Formly v6 now requires Angular Version >= 11
+- **BREAKING CHANGE**: Formly v6 now requires Angular Version >= 11
 
 @ngx-formly/core
 ----------------
-- BREAKING CHANGE: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901)
+- **BREAKING CHANGE**: The defaultValue for fieldGroup and fieldArray has been changed to `undefined` instead of empty object. ([#1901](https://github.com/ngx-formly/ngx-formly/pull/1901)
 
-  before: 
+  **before**:  
   If no default value is set the `defaultValue` for formlyGroup is `{}` and for fieldArray `[]`
   
-  after:
+  **after**:  
   ```ts
   FormlyModule.forRoot({
     types: [
@@ -23,9 +23,9 @@ UPGRADE FROM 5.0 to 6.0
   })
   ```
 
-- BREAKING CHANGE: The initial value of the created FormControl has been changed from `null` to `undefined` to match the field model value. ([#1917](https://github.com/ngx-formly/ngx-formly/pull/1917))
+- **BREAKING CHANGE**: The initial value of the created FormControl has been changed from `null` to `undefined` to match the field model value. ([#1917](https://github.com/ngx-formly/ngx-formly/pull/1917))
   
-  before:
+  **before**:  
   ```ts
   let fields: FormlyFieldConfig[] = [
     {
@@ -35,7 +35,7 @@ UPGRADE FROM 5.0 to 6.0
   ]
   ```
   
-  after:
+  **after**:  
   ```ts
   let fields: FormlyFieldConfig[] = [
     {


### PR DESCRIPTION
I tried to add a migration guide for v6. I'm not sure if the fieldChanges change is a breaking change. 

@aitboudad if someone relied on #1901 they could mitigate it with extending the formGroup and formArray and setting the defaultValue, correct?
 