### PR TITLE
feat(core): lazy render hidden fields by default

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -45,3 +45,13 @@ UPGRADE FROM 5.0 to 6.0
     }
   ]
   ```
+
+- **BREAKING CHANGE**: The `lazyRender` option is enabled by default, to rely on the old behavior you need to pass `false` to that option:
+
+  ```patch
+  FormlyModule.forRoot({
+  + extras: {
+  +   lazyRender: false,
+  + },
+  }),
+  ```

--- a/demo/src/app/examples/other/hide-fields-with-animations/app.module.ts
+++ b/demo/src/app/examples/other/hide-fields-with-animations/app.module.ts
@@ -21,6 +21,7 @@ export function animationExtension(field: FormlyFieldConfig) {
     ReactiveFormsModule,
     FormlyBootstrapModule,
     FormlyModule.forRoot({
+      extras: { lazyRender: false },
       wrappers: [{ name: 'animation', component: AnimationWrapperComponent }],
       extensions: [{ name: 'animation', extension: { onPopulate: animationExtension } }],
     }),

--- a/src/core/src/lib/components/formly.field.spec.ts
+++ b/src/core/src/lib/components/formly.field.spec.ts
@@ -41,17 +41,6 @@ const renderComponent = (field: FormlyFieldConfig, opts: any = {}) => {
 };
 
 describe('FormlyField Component', () => {
-  it('should add style display none to hidden field', () => {
-    const { field, detectChanges, query } = renderComponent({ hide: true });
-    const { styles } = query('formly-field');
-
-    expect(styles.display).toEqual('none');
-
-    field.hide = false;
-    detectChanges();
-    expect(styles.display).toEqual('');
-  });
-
   it('should add field className', () => {
     const { query } = renderComponent({ className: 'foo-class' });
 
@@ -60,16 +49,16 @@ describe('FormlyField Component', () => {
 
   describe('host attrs', () => {
     it('should set style and class attrs on first render', () => {
-      const { query } = renderComponent({
-        hide: true,
-        className: 'foo',
-      });
+      const { query } = renderComponent(
+        { hide: true, className: 'foo' },
+        { config: { extras: { lazyRender: false } } },
+      );
       expect(query('formly-field').attributes.class).toEqual('foo');
       expect(query('formly-field').styles.display).toEqual('none');
     });
 
     it('should update style and class attrs on change', () => {
-      const { field, query } = renderComponent({});
+      const { field, query } = renderComponent({}, { config: { extras: { lazyRender: false } } });
 
       expect(query('formly-field').attributes.class).toEqual(undefined);
       expect(query('formly-field').styles.display).toEqual('');
@@ -156,21 +145,32 @@ describe('FormlyField Component', () => {
     expect(query('formly-type-input')).not.toBeNull();
   });
 
-  it('should lazy render field components', () => {
-    const { field, detectChanges, query, fixture } = renderComponent(
-      {
-        key: 'title',
-        type: 'input',
-        hide: true,
-      },
-      { config: { extras: { lazyRender: true } } },
-    );
+  it('should lazy render field components by default', () => {
+    const { field, detectChanges, query, fixture } = renderComponent({
+      key: 'title',
+      type: 'input',
+      hide: true,
+    });
 
     expect(query('formly-type-input')).toBeNull();
 
     field.hide = false;
     detectChanges();
     expect(query('formly-type-input')).not.toBeNull();
+  });
+
+  it('should add style display none to hidden field', () => {
+    const { field, detectChanges, query } = renderComponent(
+      { hide: true },
+      { config: { extras: { lazyRender: false } } },
+    );
+    const { styles } = query('formly-field');
+
+    expect(styles.display).toEqual('none');
+
+    field.hide = false;
+    detectChanges();
+    expect(styles.display).toEqual('');
   });
 
   it('init hooks with observables', () => {

--- a/src/core/src/lib/components/formly.field.ts
+++ b/src/core/src/lib/components/formly.field.ts
@@ -138,7 +138,7 @@ export class FormlyField implements OnInit, OnChanges, AfterContentInit, AfterVi
     this.hostObservers.forEach((hostObserver) => hostObserver.unsubscribe());
     this.hostObservers = [
       observe<boolean>(this.field, ['hide'], ({ firstChange, currentValue }) => {
-        if (!this.config.extras.lazyRender) {
+        if (this.config.extras.lazyRender === false) {
           firstChange && this.renderField(this.containerRef, this.field);
           if (!firstChange || (firstChange && currentValue)) {
             this.renderer.setStyle(this.elementRef.nativeElement, 'display', currentValue ? 'none' : '');

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -189,13 +189,11 @@ export class FieldExpressionExtension implements FormlyExtension {
       if (hide === true && c['_fields'].every((f) => !!f._hide)) {
         unregisterControl(field);
         if (resetOnHide && field.resetOnHide) {
+          assignFieldValue(field, undefined);
           field.formControl.reset({ value: undefined, disabled: field.formControl.disabled });
-          if (field.fieldGroup) {
-            assignFieldValue(field, undefined);
-
-            if (field.formControl instanceof FormArray) {
-              field.fieldGroup.length = 0;
-            }
+          field.options.fieldChanges.next({ value: undefined, field, type: 'valueChanges' });
+          if (field.fieldGroup && field.formControl instanceof FormArray) {
+            field.fieldGroup.length = 0;
           }
         }
       } else if (hide === false) {

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -67,10 +67,10 @@ export interface ConfigOption {
 
     /**
      * Whether to lazily render field components or not when marked as hidden.
-     * - `true`: lazily render field components (Will be set by default in the next major version).
+     * - `true`: lazily render field components.
      * - `false`: render field components and use CSS to control their visibility.
      *
-     * Defaults to `false`.
+     * Defaults to `true`.
      */
     lazyRender?: boolean;
 

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -25,7 +25,7 @@ export class FormlyConfig {
   messages: { [name: string]: ValidationMessageOption['message'] } = {};
   extras: ConfigOption['extras'] = {
     checkExpressionOn: 'changeDetectionCheck',
-    lazyRender: false,
+    lazyRender: true,
     showError(field: FieldType) {
       return (
         field.formControl &&

--- a/src/schematics/src/ng-add/index.ts
+++ b/src/schematics/src/ng-add/index.ts
@@ -46,7 +46,7 @@ function addFormlyModuleConfig(options: Schema) {
     addModuleImportToModule(
       host,
       modulePath,
-      'FormlyModule.forRoot({ extras: { lazyRender: true } })',
+      'FormlyModule.forRoot()',
       '@ngx-formly/core',
     );
 


### PR DESCRIPTION
BREAKING CHANGE: The `lazyRender` option is enabled by default
