### PR TITLE
feat(core): allow control resetOnHide for a specific field

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -46,12 +46,34 @@ UPGRADE FROM 5.0 to 6.0
   ]
   ```
 
-- **BREAKING CHANGE**: The `lazyRender` option is enabled by default, to rely on the old behavior you need to pass `false` to that option:
+- **BREAKING CHANGE**: The `lazyRender` option is enabled by default, which remove the hidden fields from the DOM instead of using CSS to control their visibility. To rely on the old behavior you need to pass `false` to `lazyRender`:
 
   ```patch
   FormlyModule.forRoot({
   + extras: {
   +   lazyRender: false,
+  + },
+  }),
+  ```
+
+- **BREAKING CHANGE**: The `resetFieldOnHide` option is enabled by default, which remove the field value from the model on hide.
+
+  To disable this feature for a specific field use `resetOnHide`:
+  ```patch
+  let fields: FormlyFieldConfig[] = [
+    {
+      key: 'text',
+      type: 'input',
+  +   resetOnHide: false
+    }
+  ]
+  ```
+
+  To use the the old behavior pass `false` to `resetFieldOnHide`:
+  ```patch
+  FormlyModule.forRoot({
+  + extras: {
+  +   resetFieldOnHide: false,
   + },
   }),
   ```

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -65,7 +65,7 @@ export class FormlyJsonschema {
     };
 
     if (options.resetOnHide) {
-      field['resetOnHide'] = true;
+      field.resetOnHide = true;
     }
 
     if (options.shareFormControl === false) {

--- a/src/core/src/lib/models/fieldconfig.cache.ts
+++ b/src/core/src/lib/models/fieldconfig.cache.ts
@@ -9,7 +9,6 @@ export interface FormlyFieldConfigCache extends FormlyFieldConfig {
   formControl?: AbstractControl;
   parent?: FormlyFieldConfigCache;
   options?: FormlyFormOptionsCache;
-  resetOnHide?: boolean;
   _expressions?: { [property: string]: (ingoreCache: boolean) => boolean };
   _hide?: boolean;
   _validators?: ValidatorFn[];

--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -88,6 +88,11 @@ export interface FormlyFieldConfig {
   hide?: boolean;
 
   /**
+   * Whether to reset the value on hide or not. Defaults to `true`.
+   */
+  resetOnHide?: boolean;
+
+  /**
    * Conditionally hiding Field based on values from other Fields
    */
   hideExpression?: boolean | string | ((model: any, formState: any, field?: FormlyFieldConfig) => boolean);

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -26,6 +26,7 @@ export class FormlyConfig {
   extras: ConfigOption['extras'] = {
     checkExpressionOn: 'changeDetectionCheck',
     lazyRender: true,
+    resetFieldOnHide: true,
     showError(field: FieldType) {
       return (
         field.formControl &&


### PR DESCRIPTION
BREAKING CHANGE: The `resetFieldOnHide` option is enabled by default
fix: #2570
