### PR TITLE
feat(core): check expression on change only

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -46,6 +46,16 @@ UPGRADE FROM 5.0 to 6.0
   ]
   ```
 
+- The `checkExpressionOn` option is set to `modelChange` by default, which improve performance. To rely on the old behavior you need to pass `changeDetectionCheck` to `checkExpressionOn`:
+
+  ```patch
+  FormlyModule.forRoot({
+  + extras: {
+  +   checkExpressionOn: 'changeDetectionCheck',
+  + },
+  }),
+  ```
+
 - The `lazyRender` option is enabled by default, which remove the hidden fields from the DOM instead of using CSS to control their visibility. To rely on the old behavior you need to pass `false` to `lazyRender`:
 
   ```patch

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { JSONSchema7, JSONSchema7TypeName } from 'json-schema';
-import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup } from '@angular/forms';
 import {
-  ɵdefineHiddenProp as defineHiddenProp,
   ɵreverseDeepMerge as reverseDeepMerge,
   ɵgetFieldInitialValue as getFieldInitialValue,
   ɵclone as clone,
+  ɵisNil as isNil,
 } from '@ngx-formly/core';
 
 export interface FormlyJsonschemaOptions {
@@ -32,7 +32,7 @@ function isConst(schema: JSONSchema7) {
 
 function totalMatchedFields(field: FormlyFieldConfig): number {
   if (!field.fieldGroup) {
-    return field.key && getFieldInitialValue(field) !== undefined ? 1 : 0;
+    return !isNil(field.key) && getFieldInitialValue(field) !== undefined ? 1 : 0;
   }
 
   return field.fieldGroup.reduce((s, f) => totalMatchedFields(f) + s, 0);

--- a/src/core/src/lib/components/formly.field.ts
+++ b/src/core/src/lib/components/formly.field.ts
@@ -18,7 +18,7 @@ import {
 import { FormControl } from '@angular/forms';
 import { FormlyConfig } from '../services/formly.config';
 import { FormlyFieldConfig, FormlyFieldConfigCache } from '../models';
-import { defineHiddenProp, observe, observeDeep, getFieldValue, assignFieldValue, isObject } from '../utils';
+import { defineHiddenProp, observe, observeDeep, getFieldValue, assignFieldValue, isObject, isNil } from '../utils';
 import { FieldWrapper } from '../templates/field.wrapper';
 import { FieldType } from '../templates/field.type';
 import { isObservable } from 'rxjs';
@@ -203,7 +203,7 @@ export class FormlyField implements OnInit, OnChanges, AfterContentInit, AfterVi
       subscribes.push(() => fieldObserver.unsubscribe());
     }
 
-    if (field.key && !field.fieldGroup) {
+    if (field.formControl && !field.fieldGroup) {
       const control = field.formControl;
       let valueChanges = control.valueChanges.pipe(
         distinctUntilChanged((x, y) => {
@@ -231,7 +231,9 @@ export class FormlyField implements OnInit, OnChanges, AfterContentInit, AfterVi
         }
 
         field.parsers?.forEach((parserFn) => (value = parserFn(value)));
-        assignFieldValue(field, value);
+        if (!isNil(field.key)) {
+          assignFieldValue(field, value);
+        }
         field.options.fieldChanges.next({ value, field, type: 'valueChanges' });
       });
 

--- a/src/core/src/lib/components/formly.form.spec.ts
+++ b/src/core/src/lib/components/formly.form.spec.ts
@@ -287,7 +287,7 @@ describe('FormlyForm Component', () => {
     });
 
     it('should hide/display field using a function with nested field key', () => {
-      const { form, model, fields, detectChanges } = renderComponent({
+      const { form, model, fields, detectChanges, setInputs } = renderComponent({
         model: { address: [{ city: '' }] },
         fields: [
           {
@@ -299,7 +299,7 @@ describe('FormlyForm Component', () => {
 
       expect(form.get('address.0.city')).toBeNull();
 
-      model.address[0].city = 'agadir';
+      setInputs({ model: { address: [{ city: 'agadir' }] } });
       detectChanges();
 
       expect(form.get('address.0.city')).not.toBeNull();
@@ -585,7 +585,7 @@ describe('FormlyForm Component', () => {
   });
 
   it('should keep in sync UI on checkExpressionChange', () => {
-    const { form, query, detectChanges } = renderComponent(
+    const { form, query, fields, fixture, detectChanges } = renderComponent(
       {
         fields: [
           {
@@ -602,7 +602,7 @@ describe('FormlyForm Component', () => {
 
     const input = query('input');
     input.triggerEventHandler('input', { target: { value: '***' } });
-    detectChanges();
+    fixture.autoDetectChanges();
 
     const control = form.get('city');
     expect(control.disabled).toBeTrue();

--- a/src/core/src/lib/core.ts
+++ b/src/core/src/lib/core.ts
@@ -15,3 +15,4 @@ export { reverseDeepMerge as ɵreverseDeepMerge } from './utils';
 export { getFieldInitialValue as ɵgetFieldInitialValue } from './utils';
 export { clone as ɵclone } from './utils';
 export { observe as ɵobserve } from './utils';
+export { isNil as ɵisNil } from './utils';

--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -9,6 +9,7 @@ import {
   reverseDeepMerge,
   defineHiddenProp,
   clone,
+  isNil,
 } from '../../utils';
 import { Subject } from 'rxjs';
 
@@ -23,7 +24,7 @@ export class CoreExtension implements FormlyExtension {
     if (root) {
       Object.defineProperty(field, 'options', { get: () => root.options, configurable: true });
       Object.defineProperty(field, 'model', {
-        get: () => (field.key && field.fieldGroup ? getFieldValue(field) : root.model),
+        get: () => (!isNil(field.key) && field.fieldGroup ? getFieldValue(field) : root.model),
         configurable: true,
       });
     }
@@ -75,6 +76,7 @@ export class CoreExtension implements FormlyExtension {
 
     options.detectChanges = (f: FormlyFieldConfigCache) => {
       if (f._componentRefs) {
+        f.options.checkExpressions(f.parent);
         f._componentRefs.forEach((ref) => {
           // NOTE: we cannot use ref.changeDetectorRef, see https://github.com/ngx-formly/ngx-formly/issues/2191
           const changeDetectorRef = ref.injector.get(ChangeDetectorRef);
@@ -111,7 +113,7 @@ export class CoreExtension implements FormlyExtension {
       hooks: {},
       modelOptions: {},
       templateOptions:
-        !field.type || !field.key
+        !field.type || isNil(field.key)
           ? {}
           : {
               label: '',
@@ -139,7 +141,7 @@ export class CoreExtension implements FormlyExtension {
       this.config.getMergedField(field);
     }
 
-    if (!isUndefined(field.key) && !isUndefined(field.defaultValue) && isUndefined(getFieldValue(field))) {
+    if (!isNil(field.key) && !isUndefined(field.defaultValue) && isUndefined(getFieldValue(field))) {
       let setDefaultValue = !field.resetOnHide || !(field.hide || field.hideExpression);
       if (setDefaultValue && field.resetOnHide) {
         let parent = field.parent;

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -173,13 +173,13 @@ export class FieldExpressionExtension implements FormlyExtension {
         .forEach((f) => this.changeDisabledState(f, value));
     }
 
-    if (field.key && field.templateOptions.disabled !== value) {
+    if (!isNil(field.key) && field.templateOptions.disabled !== value) {
       field.templateOptions.disabled = value;
     }
   }
 
   private changeHideState(field: FormlyFieldConfigCache, hide: boolean, resetOnHide: boolean) {
-    if (field.formControl && field.key) {
+    if (field.formControl && !isNil(field.key)) {
       defineHiddenProp(field, '_hide', !!(hide || field.hide));
       const c = field.formControl;
       if (c['_fields'].length > 1) {
@@ -231,7 +231,7 @@ export class FieldExpressionExtension implements FormlyExtension {
       throw error;
     }
 
-    if (prop === 'templateOptions.disabled' && field.key) {
+    if (prop === 'templateOptions.disabled' && !isNil(field.key)) {
       this.changeDisabledState(field, value);
     }
 

--- a/src/core/src/lib/extensions/field-form/field-form.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.ts
@@ -7,7 +7,7 @@ import {
   ValidatorFn,
   AsyncValidatorFn,
 } from '@angular/forms';
-import { getFieldValue, defineHiddenProp } from '../../utils';
+import { getFieldValue, defineHiddenProp, isNil } from '../../utils';
 import { registerControl, findControl, updateValidity as updateControlValidity } from './utils';
 import { of } from 'rxjs';
 
@@ -28,7 +28,7 @@ export class FieldFormExtension implements FormlyExtension {
   }
 
   onPopulate(field: FormlyFieldConfigCache) {
-    if (field.hasOwnProperty('fieldGroup') && !field.key) {
+    if (field.hasOwnProperty('fieldGroup') && isNil(field.key)) {
       defineHiddenProp(field, 'formControl', field.form);
     } else {
       this.addFormControl(field);
@@ -61,7 +61,7 @@ export class FieldFormExtension implements FormlyExtension {
       if (field.fieldGroup) {
         control = new FormGroup({}, controlOptions);
       } else {
-        const value = field.key ? getFieldValue(field) : field.defaultValue;
+        const value = !isNil(field.key) ? getFieldValue(field) : field.defaultValue;
         control = new FormControl({ value, disabled: false }, controlOptions);
       }
     }
@@ -71,7 +71,7 @@ export class FieldFormExtension implements FormlyExtension {
 
   private setValidators(field: FormlyFieldConfigCache) {
     let updateValidity = false;
-    if (field.key || !field.parent || (!field.key && !field.fieldGroup)) {
+    if (!isNil(field.key) || !field.parent || (isNil(field.key) && !field.fieldGroup)) {
       const { formControl: c } = field;
       const disabled = field.templateOptions ? field.templateOptions.disabled : false;
       if (disabled && c.enabled) {
@@ -129,7 +129,7 @@ export class FieldFormExtension implements FormlyExtension {
 
     if (field.fieldGroup) {
       field.fieldGroup
-        .filter((f) => f?.fieldGroup && !f.key)
+        .filter((f) => f?.fieldGroup && isNil(f.key))
         .forEach((f) => validators.push(...this.mergeValidators(f, type)));
     }
 

--- a/src/core/src/lib/extensions/field-form/utils.ts
+++ b/src/core/src/lib/extensions/field-form/utils.ts
@@ -70,7 +70,7 @@ export function registerControl(field: FormlyFieldConfigCache, control?: any, em
     }
   }
 
-  if (!field.form || !field.key) {
+  if (!field.form || isNil(field.key)) {
     return;
   }
 

--- a/src/core/src/lib/extensions/field-validation/field-validation.ts
+++ b/src/core/src/lib/extensions/field-validation/field-validation.ts
@@ -1,7 +1,7 @@
 import { FormlyConfig } from '../../services/formly.config';
 import { FormlyExtension, ValidatorOption, FormlyFieldConfigCache } from '../../models';
 import { AbstractControl, Validators, ValidatorFn } from '@angular/forms';
-import { FORMLY_VALIDATORS, defineHiddenProp, isPromise, observe, clone, isObject } from '../../utils';
+import { FORMLY_VALIDATORS, defineHiddenProp, isPromise, observe, clone, isObject, isNil } from '../../utils';
 import { updateValidity } from '../field-form/utils';
 import { isObservable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -17,7 +17,7 @@ export class FieldValidationExtension implements FormlyExtension {
 
   private initFieldValidation(field: FormlyFieldConfigCache, type: 'validators' | 'asyncValidators') {
     const validators: ValidatorFn[] = [];
-    if (type === 'validators' && !(field.hasOwnProperty('fieldGroup') && !field.key)) {
+    if (type === 'validators' && !(field.hasOwnProperty('fieldGroup') && isNil(field.key))) {
       validators.push(this.getPredefinedFieldValidation(field));
     }
 

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -24,7 +24,7 @@ export class FormlyConfig {
   wrappers: { [name: string]: WrapperOption } = {};
   messages: { [name: string]: ValidationMessageOption['message'] } = {};
   extras: ConfigOption['extras'] = {
-    checkExpressionOn: 'changeDetectionCheck',
+    checkExpressionOn: 'modelChange',
     lazyRender: true,
     resetFieldOnHide: true,
     showError(field: FieldType) {

--- a/src/core/src/lib/templates/field-array.type.ts
+++ b/src/core/src/lib/templates/field-array.type.ts
@@ -1,7 +1,7 @@
 import { Directive } from '@angular/core';
 import { FormArray } from '@angular/forms';
 import { FieldType } from './field.type';
-import { clone, assignFieldValue, getFieldValue } from '../utils';
+import { clone, assignFieldValue, getFieldValue, isNil } from '../utils';
 import { FormlyFieldConfig, FormlyExtension } from '../models';
 import { registerControl, unregisterControl, findControl } from '../extensions/field-form/utils';
 
@@ -14,7 +14,7 @@ export abstract class FieldArrayType<F extends FormlyFieldConfig = FormlyFieldCo
   }
 
   onPopulate(field: FormlyFieldConfig) {
-    if (!field.formControl && field.key) {
+    if (!field.formControl && !isNil(field.key)) {
       const control = findControl(field);
       registerControl(field, control ? control : new FormArray([], { updateOn: field.modelOptions.updateOn }));
     }


### PR DESCRIPTION
BREAKING CHANGE: The `checkExpressionOn` option is set to `modelChange` instead of `changeDetectionCheck`
