### PR TITLE
feat(core): add type of templateOptions accessor "to"

### DIFF
--- a/src/core/src/lib/templates/field.type.ts
+++ b/src/core/src/lib/templates/field.type.ts
@@ -1,5 +1,5 @@
 import { Input, Directive } from '@angular/core';
-import { FormlyFieldConfig } from '../models';
+import { FormlyFieldConfig, FormlyTemplateOptions } from '../models';
 
 @Directive()
 export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig> {
@@ -26,8 +26,12 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
     return this.field.formControl;
   }
 
-  get to() {
-    return this.field.templateOptions || {};
+  get to(): NonNullable<Required<F>['templateOptions']> {
+    if (!!this.field.templateOptions) {
+      return this.field.templateOptions as NonNullable<Required<F>['templateOptions']>;
+    } else {
+      return {} as NonNullable<Required<F>['templateOptions']>;
+    }
   }
 
   get showError(): boolean {

--- a/src/core/src/lib/templates/formly.attributes.ts
+++ b/src/core/src/lib/templates/formly.attributes.ts
@@ -40,8 +40,8 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
     events: ['click', 'keyup', 'keydown', 'keypress'],
   };
 
-  get to(): FormlyTemplateOptions {
-    return this.field.templateOptions || {};
+  get to() {
+    return this.field.templateOptions || ({} as FormlyTemplateOptions);
   }
 
   private get fieldAttrElements(): ElementRef[] {

--- a/src/ui/material/checkbox/src/checkbox.type.ts
+++ b/src/ui/material/checkbox/src/checkbox.type.ts
@@ -7,11 +7,9 @@ import {
   OnDestroy,
   AfterViewInit,
 } from '@angular/core';
-import { FieldType, MatFormlyTemplateOptions } from '@ngx-formly/material/form-field';
+import { FieldType } from '@ngx-formly/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { FloatLabelType } from '@angular/material/form-field/form-field';
-import { ThemePalette } from '@angular/material/core';
 
 @Component({
   selector: 'formly-field-mat-checkbox',

--- a/src/ui/material/checkbox/src/checkbox.type.ts
+++ b/src/ui/material/checkbox/src/checkbox.type.ts
@@ -7,9 +7,11 @@ import {
   OnDestroy,
   AfterViewInit,
 } from '@angular/core';
-import { FieldType } from '@ngx-formly/material/form-field';
+import { FieldType, MatFormlyTemplateOptions } from '@ngx-formly/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FocusMonitor } from '@angular/cdk/a11y';
+import { FloatLabelType } from '@angular/material/form-field/form-field';
+import { ThemePalette } from '@angular/material/core';
 
 @Component({
   selector: 'formly-field-mat-checkbox',
@@ -35,10 +37,10 @@ export class FormlyFieldCheckbox extends FieldType implements AfterViewInit, Aft
     templateOptions: {
       hideFieldUnderline: true,
       indeterminate: true,
-      floatLabel: 'always',
+      floatLabel: 'always' as const,
       hideLabel: true,
       align: 'start', // start or end
-      color: 'accent', // workaround for https://github.com/angular/components/issues/18465
+      color: 'accent' as const, // workaround for https://github.com/angular/components/issues/18465
     },
   };
 

--- a/src/ui/material/form-field/src/field.type.ts
+++ b/src/ui/material/form-field/src/field.type.ts
@@ -9,13 +9,14 @@ import {
   ViewChildren,
   QueryList,
 } from '@angular/core';
-import { FieldType as CoreFieldType, FormlyFieldConfig, ɵobserve as observe } from '@ngx-formly/core';
+import { FieldType as CoreFieldType, ɵobserve as observe } from '@ngx-formly/core';
 import { Subject } from 'rxjs';
 import { MatFormField, MatFormFieldControl } from '@angular/material/form-field';
 import { ErrorStateMatcher } from '@angular/material/core';
+import { MatFormlyFieldConfig } from './form-field.wrapper';
 
 @Directive()
-export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
+export abstract class FieldType<F extends MatFormlyFieldConfig = MatFormlyFieldConfig>
   extends CoreFieldType<F>
   implements OnInit, AfterViewInit, OnDestroy, MatFormFieldControl<any> {
   @ViewChild('matPrefix') matPrefix!: TemplateRef<any>;

--- a/src/ui/material/form-field/src/field.type.ts
+++ b/src/ui/material/form-field/src/field.type.ts
@@ -13,10 +13,10 @@ import { FieldType as CoreFieldType, ɵobserve as observe } from '@ngx-formly/co
 import { Subject } from 'rxjs';
 import { MatFormField, MatFormFieldControl } from '@angular/material/form-field';
 import { ErrorStateMatcher } from '@angular/material/core';
-import { MatFormlyFieldConfig } from './form-field.wrapper';
+import { FormlyFieldConfig } from './form-field.wrapper';
 
 @Directive()
-export abstract class FieldType<F extends MatFormlyFieldConfig = MatFormlyFieldConfig>
+export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
   extends CoreFieldType<F>
   implements OnInit, AfterViewInit, OnDestroy, MatFormFieldControl<any> {
   @ViewChild('matPrefix') matPrefix!: TemplateRef<any>;

--- a/src/ui/material/form-field/src/form-field.wrapper.ts
+++ b/src/ui/material/form-field/src/form-field.wrapper.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import {
   ɵdefineHiddenProp as defineHiddenProp,
-  FormlyFieldConfig,
+  FormlyFieldConfig as CoreFieldConfig,
   FormlyTemplateOptions,
   FieldWrapper,
 } from '@ngx-formly/core';
@@ -20,14 +20,17 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { FloatLabelType, MatFormFieldAppearance } from '@angular/material/form-field/form-field';
 import { ThemePalette } from '@angular/material/core';
 
-export interface MatFormlyFieldConfig extends FormlyFieldConfig {
+interface MatFormlyFieldConfig extends FormlyFieldConfig {
   _matprefix?: TemplateRef<any>;
   _matsuffix?: TemplateRef<any>;
   _formField?: FormlyWrapperFormField;
+}
+
+export interface FormlyFieldConfig extends CoreFieldConfig {
   templateOptions?: MatFormlyTemplateOptions;
 }
 
-export interface MatFormlyTemplateOptions extends FormlyTemplateOptions {
+interface MatFormlyTemplateOptions extends FormlyTemplateOptions {
   prefix?: TemplateRef<any>;
   suffix?: TemplateRef<any>;
   hideLabel?: boolean;

--- a/src/ui/material/form-field/src/form-field.wrapper.ts
+++ b/src/ui/material/form-field/src/form-field.wrapper.ts
@@ -8,21 +8,36 @@ import {
   AfterViewInit,
   TemplateRef,
   ElementRef,
-  ViewContainerRef,
 } from '@angular/core';
 import {
   ɵdefineHiddenProp as defineHiddenProp,
-  ɵobserve as observe,
   FormlyFieldConfig,
+  FormlyTemplateOptions,
   FieldWrapper,
 } from '@ngx-formly/core';
 import { MatFormField } from '@angular/material/form-field';
 import { FocusMonitor } from '@angular/cdk/a11y';
+import { FloatLabelType, MatFormFieldAppearance } from '@angular/material/form-field/form-field';
+import { ThemePalette } from '@angular/material/core';
 
-interface MatFormlyFieldConfig extends FormlyFieldConfig {
-  _matprefix: TemplateRef<any>;
-  _matsuffix: TemplateRef<any>;
+export interface MatFormlyFieldConfig extends FormlyFieldConfig {
+  _matprefix?: TemplateRef<any>;
+  _matsuffix?: TemplateRef<any>;
   _formField?: FormlyWrapperFormField;
+  templateOptions?: MatFormlyTemplateOptions;
+}
+
+export interface MatFormlyTemplateOptions extends FormlyTemplateOptions {
+  prefix?: TemplateRef<any>;
+  suffix?: TemplateRef<any>;
+  hideLabel?: boolean;
+  hideRequiredMarker?: boolean;
+  hideFieldUnderline?: boolean;
+  floatLabel?: FloatLabelType;
+  appearance?: MatFormFieldAppearance;
+  color?: ThemePalette;
+  hintStart?: TemplateRef<any> | string;
+  hintEnd?: TemplateRef<any> | string;
 }
 
 @Component({

--- a/src/ui/material/form-field/src/public_api.ts
+++ b/src/ui/material/form-field/src/public_api.ts
@@ -1,2 +1,3 @@
 export { FormlyMatFormFieldModule } from './form-field.module';
 export { FieldType } from './field.type';
+export { MatFormlyFieldConfig, MatFormlyTemplateOptions } from './form-field.wrapper';

--- a/src/ui/material/form-field/src/public_api.ts
+++ b/src/ui/material/form-field/src/public_api.ts
@@ -1,3 +1,3 @@
 export { FormlyMatFormFieldModule } from './form-field.module';
 export { FieldType } from './field.type';
-export { MatFormlyFieldConfig, MatFormlyTemplateOptions } from './form-field.wrapper';
+export { FormlyFieldConfig } from './form-field.wrapper';

--- a/src/ui/material/multicheckbox/src/multicheckbox.type.ts
+++ b/src/ui/material/multicheckbox/src/multicheckbox.type.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, ViewChildren, QueryList } from '@angular/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-multicheckbox',
@@ -28,9 +29,9 @@ export class FormlyFieldMultiCheckbox extends FieldType {
   defaultOptions = {
     templateOptions: {
       hideFieldUnderline: true,
-      floatLabel: 'always',
+      floatLabel: 'always' as const,
       options: [],
-      color: 'accent', // workaround for https://github.com/angular/components/issues/18465
+      color: 'accent' as const, // workaround for https://github.com/angular/components/issues/18465
     },
   };
 

--- a/src/ui/material/multicheckbox/src/multicheckbox.type.ts
+++ b/src/ui/material/multicheckbox/src/multicheckbox.type.ts
@@ -1,7 +1,6 @@
 import { Component, ChangeDetectionStrategy, ViewChildren, QueryList } from '@angular/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-multicheckbox',

--- a/src/ui/material/radio/src/radio.type.ts
+++ b/src/ui/material/radio/src/radio.type.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy, ViewChild, AfterViewInit, OnDestroy
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatRadioGroup } from '@angular/material/radio';
 import { ɵobserve as observe } from '@ngx-formly/core';
-import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-radio',

--- a/src/ui/material/radio/src/radio.type.ts
+++ b/src/ui/material/radio/src/radio.type.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, ViewChild, AfterViewInit, OnDestroy
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatRadioGroup } from '@angular/material/radio';
 import { ɵobserve as observe } from '@ngx-formly/core';
+import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-radio',
@@ -31,7 +32,7 @@ export class FormlyFieldRadio extends FieldType implements AfterViewInit, OnDest
   defaultOptions = {
     templateOptions: {
       hideFieldUnderline: true,
-      floatLabel: 'always',
+      floatLabel: 'always' as const,
       options: [],
       tabindex: -1,
     },

--- a/src/ui/material/slider/src/slider.type.ts
+++ b/src/ui/material/slider/src/slider.type.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, ViewChild } from '@angular/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatSlider } from '@angular/material/slider';
+import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-slider',
@@ -26,7 +27,7 @@ export class FormlySliderTypeComponent extends FieldType {
   defaultOptions = {
     templateOptions: {
       hideFieldUnderline: true,
-      floatLabel: 'always',
+      floatLabel: 'always' as const,
       thumbLabel: false,
     },
   };

--- a/src/ui/material/slider/src/slider.type.ts
+++ b/src/ui/material/slider/src/slider.type.ts
@@ -1,7 +1,6 @@
 import { Component, ChangeDetectionStrategy, ViewChild } from '@angular/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatSlider } from '@angular/material/slider';
-import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-slider',

--- a/src/ui/material/toggle/src/toggle.type.ts
+++ b/src/ui/material/toggle/src/toggle.type.ts
@@ -1,7 +1,6 @@
 import { Component, ChangeDetectionStrategy, ViewChild } from '@angular/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
-import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-toggle',

--- a/src/ui/material/toggle/src/toggle.type.ts
+++ b/src/ui/material/toggle/src/toggle.type.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, ViewChild } from '@angular/core';
 import { FieldType } from '@ngx-formly/material/form-field';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { FloatLabelType } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'formly-field-mat-toggle',
@@ -23,7 +24,7 @@ export class FormlyToggleTypeComponent extends FieldType {
   defaultOptions = {
     templateOptions: {
       hideFieldUnderline: true,
-      floatLabel: 'always',
+      floatLabel: 'always' as const,
       hideLabel: true,
     },
   };

--- a/src/ui/material/tsconfig.lib.json
+++ b/src/ui/material/tsconfig.lib.json
@@ -17,7 +17,9 @@
     "lib": ["dom", "es2018"],
     "paths": {
       "@ngx-formly/core": ["dist/@ngx-formly/core"],
-      "@ngx-formly/core/*": ["dist/@ngx-formly/core/*"]
+      "@ngx-formly/core/*": ["dist/@ngx-formly/core/*"],
+      "@ngx-formly/material": ["dist/@ngx-formly/material"],
+      "@ngx-formly/material/*": ["dist/@ngx-formly/material/*"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature Request: Use typing of templateOptions given in generic FormlyFieldConfig _F_ in `FieldType<F>.to`

**What is the current behavior? (You can also link to an open issue here)**
The type of value accessor `FieldType.to` is always `FormlyTemplateOptions`, even when you provide additional typing.
```ts
export declare abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig> {
    field: F;
    get to(): FormlyTemplateOptions;
}
```

**What is the new behavior (if this is a feature change)?**
The return type of `to` is a `NonNullable` type of `templateOptions` of the generic field _F_ 
```ts
export declare abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig> {
    field: F;
    get to(): NonNullable<Required<F>['templateOptions']>;
}
```

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)