### PR TITLE
feat(core): add additionalWrappers attribute

### DIFF
--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -83,6 +83,12 @@ export interface FormlyFieldConfig {
   wrappers?: string[];
 
   /**
+   * It is expected to be the name of defined wrappers.
+   * These wrappers will be added to the default ones after instead of replacing them.
+   */
+  additionalWrappers?: string[];
+
+  /**
    * Whether to hide the field. Defaults to false. If you wish this to be conditional use `hideExpression`
    */
   hide?: boolean;

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -111,7 +111,9 @@ export class FormlyConfig {
     }
 
     if (!field.wrappers && type.wrappers) {
-      field.wrappers = [...type.wrappers];
+      field.wrappers = [...type.wrappers, ...(field.additionalWrappers ?? [])];
+    } else if (field.wrappers) {
+      field.wrappers = [...field.wrappers, ...(field.additionalWrappers ?? [])];
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
Currently, setting a fields wrappers completely overrides the default wrappers defined in the module. 

**What is the new behavior (if this is a feature change)?**
This PR introduces an "additionalWrappers" attribute which lets you set wrappers to be added after the default ones.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
