### PR TITLE
fix(json-schema): do not override widget.formlyConfig.key

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -1343,6 +1343,66 @@ describe('Service: FormlyJsonschema', () => {
 
       expect(to.label).toBe('Age');
     });
+    it('should be possible to set the key via formlyConfig', () => {
+      const schema: JSONSchema7 = JSON.parse(`{
+        "title": "Custom model Key",
+        "type": "object",
+        "properties": {
+          "withkey": {
+            "type": "string",
+            "title": "With Key",
+            "widget": {
+              "formlyConfig": {
+                "key": "custom.key.path"
+              }
+            }
+          },
+          "withNumericKey": {
+            "type": "string",
+            "title": "With Key",
+            "widget": {
+              "formlyConfig": {
+                "key": 0
+              }
+            }
+          },
+          "withArrayKey": {
+            "type": "string",
+            "title": "With Key",
+            "widget": {
+              "formlyConfig": {
+                "key": []
+              }
+            }
+          },
+          "withoutKey": {
+            "type": "string",
+            "title": "Without key"
+          },
+          "alsoWithoutKey": {
+            "type": "string",
+            "title": "Also without key",
+            "widget": {
+              "formlyConfig": {
+                "templateOptions": {
+                  "type": "date"
+                }
+              }
+            }
+          }
+        }
+      }`);
+      const fields = formlyJsonschema.toFieldConfig(schema);
+      expect(fields.fieldGroup).toBeDefined();
+      const fg = fields.fieldGroup;
+      expect(fg.length).toEqual(5);
+      expect(fg[0].key).toEqual('custom.key.path');
+      expect(fg[1].key).toEqual(0);
+      expect(fg[2].key).toEqual([]);
+      // Check the falsy path also
+      expect(fg[3].key).toEqual('withoutKey');
+      expect(fg[4].key).toEqual('alsoWithoutKey');
+    });
   });
 
   describe('FormlyJsonSchemaOptions map function', () => {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -45,6 +45,7 @@ interface IOptions extends FormlyJsonschemaOptions {
   shareFormControl?: boolean;
   ignoreDefault?: boolean;
   readOnly?: boolean;
+  key?: FormlyFieldConfig['key'];
 }
 
 @Injectable({ providedIn: 'root' })
@@ -53,7 +54,7 @@ export class FormlyJsonschema {
     return this._toFieldConfig(schema, { schema, ...(options || {}) });
   }
 
-  private _toFieldConfig(schema: JSONSchema7, options: IOptions): FormlyFieldConfig {
+  private _toFieldConfig(schema: JSONSchema7, { key, ...options }: IOptions): FormlyFieldConfig {
     schema = this.resolveSchema(schema, options);
 
     let field: FormlyFieldConfig = {
@@ -65,6 +66,10 @@ export class FormlyJsonschema {
         description: schema.description,
       },
     };
+
+    if (key != null) {
+      field.key = key;
+    }
 
     if (!options.ignoreDefault && (schema.readOnly || options.readOnly)) {
       field.templateOptions.disabled = true;
@@ -139,9 +144,8 @@ export class FormlyJsonschema {
 
         const [propDeps, schemaDeps] = this.resolveDependencies(schema);
         Object.keys(schema.properties || {}).forEach(key => {
-          const f = this._toFieldConfig(<JSONSchema7> schema.properties[key], options);
+          const f = this._toFieldConfig(<JSONSchema7> schema.properties[key], { ...options, key });
           field.fieldGroup.push(f);
-          f.key = key;
           if (Array.isArray(schema.required) && schema.required.indexOf(key) !== -1) {
             f.templateOptions.required = true;
           }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

The fix avoids that a key property (`widget.formlyConfig.key`) is overridden by the schema key.

**What is the current behavior? (You can also link to an open issue here)**

The model key is always the property key from the json-shema.

**What is the new behavior (if this is a feature change)?**

The schema key is only set when no key property is given by `widget.formlyConfig`

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**

no visual feature

**Other information**:

I'm not sure if checking for empty `strings` or `arrays` would be useful.
