### PR TITLE
fix(json-schema): do not replace expression properties if required fi…

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -387,6 +387,32 @@ describe('Service: FormlyJsonschema', () => {
           fixture.detectChanges();
           expect(childField.templateOptions.required).toBeTruthy();
         });
+
+        it('should not kill other expressionProperties', () => {
+          const {field} = renderComponent(JSON.parse(`{
+            "schema": {
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "widget": {
+                    "formlyConfig": {
+                      "expressionProperties": {
+                        "templateOptions.readonly": "model.readonly"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }`));
+
+          const childField = field.fieldGroup[0];
+          expect(childField.expressionProperties['templateOptions.readonly']).toEqual('model.readonly');
+        });
       });
 
       describe('dependencies', () => {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -154,10 +154,8 @@ export class FormlyJsonschema {
             (Array.isArray(schema.required) && schema.required.indexOf(property) !== -1)
             || propDeps[property]
           ) {
-            if (!f.expressionProperties) {
-              f.expressionProperties = {};
-            }
-            f.expressionProperties =  { ...f.expressionProperties,
+            f.expressionProperties =  {
+              ...(f.expressionProperties || {}),
               'templateOptions.required': (m, s, f) => {
                 const { model, templateOptions: { required } } = f.parent ? f.parent : { templateOptions: {} } as any;
                 if (!model && !required) {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -154,7 +154,10 @@ export class FormlyJsonschema {
             (Array.isArray(schema.required) && schema.required.indexOf(property) !== -1)
             || propDeps[property]
           ) {
-            f.expressionProperties = {
+            if (!f.expressionProperties) {
+              f.expressionProperties = {};
+            }
+            f.expressionProperties =  { ...f.expressionProperties,
               'templateOptions.required': (m, s, f) => {
                 const { model, templateOptions: { required } } = f.parent ? f.parent : { templateOptions: {} } as any;
                 if (!model && !required) {


### PR DESCRIPTION
…elds are set

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Avoid override of expression properties if required fields are set.

**What is the current behavior? (You can also link to an open issue here)**

The expression properties from schema are completely replaced if the field is also set as required.

**What is the new behavior (if this is a feature change)?**

The expression properties will be extended instead of replaced.

**Please check if the PR fulfills these requirements**
- [*] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [*] A unit test has been written for this change.
- [*] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [*] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**

`non visual`

**Other information**:

