### PR TITLE
feat(core):  add helper function to get the field by key

### DIFF
--- a/src/core/src/lib/extensions/core/core.spec.ts
+++ b/src/core/src/lib/extensions/core/core.spec.ts
@@ -311,4 +311,84 @@ describe('CoreExtension', () => {
       expect(f2.id).toEqual('formly_3__title_1');
     });
   });
+
+  describe('get', () => {
+    it('should find child field by key', () => {
+      const field = buildField({
+        key: 'parent',
+        fieldGroup: [
+          {
+            key: 'child1',
+            type: 'input',
+          },
+          {
+            key: 'child2',
+            type: 'input',
+          },
+          {
+            key: 'child3',
+            type: 'text',
+          },
+        ],
+      });
+      const childField = field.get('child1');
+      expect(childField.key).toEqual(field.fieldGroup[0].key);
+    });
+
+    it('should find the nested child field by key', () => {
+      const field = buildField({
+        key: 'parent',
+        fieldGroup: [
+          {
+            key: 'child1',
+            type: 'input',
+          },
+          {
+            key: 'child2',
+            type: 'input',
+          },
+          {
+            key: 'child3',
+            type: 'wrapper',
+            fieldGroup: [
+              {
+                key: 'child4',
+                type: 'input',
+              },
+              {
+                key: 'child5',
+                type: 'input',
+              },
+            ],
+          },
+        ],
+      });
+
+      const childField = field.get('child4');
+
+      expect(childField.key).toEqual(field.fieldGroup[2].fieldGroup[0].key);
+    });
+
+    it('should return null if no field was found', () => {
+      const field = buildField({
+        key: 'parent',
+        fieldGroup: [
+          {
+            key: 'child1',
+            type: 'input',
+          },
+          {
+            key: 'child2',
+            type: 'input',
+          },
+          {
+            key: 'child3',
+            type: 'text',
+          },
+        ],
+      });
+      const childField = field.get('child4');
+      expect(childField).toBeNull();
+    });
+  });
 });

--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, ComponentRef } from '@angular/core';
 import { FormlyConfig } from '../../services/formly.config';
-import { FormlyFieldConfigCache, FormlyValueChangeEvent, FormlyExtension } from '../../models';
+import { FormlyFieldConfigCache, FormlyValueChangeEvent, FormlyExtension, FormlyFieldConfig } from '../../models';
 import {
   getFieldId,
   assignFieldValue,
@@ -28,6 +28,32 @@ export class CoreExtension implements FormlyExtension {
         configurable: true,
       });
     }
+
+    Object.defineProperty(field, 'get', {
+      value: (key) => {
+        let formlyField: FormlyFieldConfig = null;
+
+        const findField = (f: FormlyFieldConfig, keyValue: string | number) => {
+          if (f.fieldGroup && f.fieldGroup.length > 0) {
+            const match = f.fieldGroup.find((fg) => fg.key && fg.key === keyValue);
+            if (match) {
+              return (formlyField = match);
+            }
+
+            for (const innerField of f.fieldGroup) {
+              if (innerField.fieldGroup) {
+                findField(innerField, keyValue);
+                if (formlyField) break;
+              }
+            }
+          } else {
+            return null;
+          }
+        };
+        findField(field, key);
+        return formlyField;
+      },
+    });
 
     this.getFieldComponentInstance(field).prePopulate();
   }

--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -148,6 +148,11 @@ export interface FormlyFieldConfig {
   parsers?: ((value: any) => any)[];
 
   /**
+   * Returns child field by key name
+   */
+  get?: (key: FormlyFieldConfig['key']) => FormlyFieldConfig;
+
+  /**
    * The model that stores all the data, where the model[key] is the value of the field
    */
   readonly model?: any;


### PR DESCRIPTION
add get method to field type

Closes #2854

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
https://github.com/ngx-formly/ngx-formly/issues/2854


**What is the new behavior (if this is a feature change)?**

field components will be able to get child field if there is a fieldGroup present. 




**Please check if the PR fulfills these requirements**
- [ x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x ] A unit test has been written for this change.
- [ x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
