### PR TITLE
feat(bootstrap): change `add-on::onClick` callback signature

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -87,3 +87,12 @@ UPGRADE FROM 5.0 to 6.0
   + },
   }),
   ```
+
+@ngx-formly/bootstrap
+---------------------
+ * add-on: The two first argument of `onClick` handler has been replaced by `field` instance.
+
+  ```patch
+  - onClick: (to, fieldType, $event) => ...,
+  + onClick: (field, $event) => ...,
+  ```

--- a/src/ui/bootstrap/addons/src/addons.component.ts
+++ b/src/ui/bootstrap/addons/src/addons.component.ts
@@ -9,10 +9,10 @@ import { FieldWrapper } from '@ngx-formly/core';
 })
 export class FormlyWrapperAddons extends FieldWrapper {
   addonRightClick($event: any) {
-    this.to.addonRight.onClick?.(this.to, this, $event);
+    this.to.addonRight.onClick?.(this.field, $event);
   }
 
   addonLeftClick($event: any) {
-    this.to.addonLeft.onClick?.(this.to, this, $event);
+    this.to.addonLeft.onClick?.(this.field, $event);
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: The two first argument of `onClick` handler has been replaced by `field` instance.

fix #2617