### PR TITLE
docs: add example for extending field types

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -83,6 +83,7 @@ export class AppComponent {
         { path: '/examples/advanced/tabs', title: 'Tabs Form' },
         { path: '/examples/advanced/grid-integration', title: 'ag-grid Integration' },
         { path: '/examples/advanced/datatable-integration', title: 'ngx-datatable Integration' },
+        { path: '/examples/advanced/extending-field-types', title: 'Extending Field Types' },
 
         { title: 'Other' },
         { path: '/examples/other/cascaded-select', title: 'Cascaded Select (using observable)' },

--- a/demo/src/app/examples/advanced/extending-field-types/app.component.html
+++ b/demo/src/app/examples/advanced/extending-field-types/app.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/demo/src/app/examples/advanced/extending-field-types/app.component.ts
+++ b/demo/src/app/examples/advanced/extending-field-types/app.component.ts
@@ -1,0 +1,39 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      templateOptions: { label: 'Personal data' },
+      fieldGroup: [
+        {
+          key: 'input',
+          type: 'input',
+          templateOptions: {
+            label: 'Input Field',
+          },
+        },
+        {
+          key: 'default-password',
+          type: 'password',
+        },
+        {
+          key: 'customized-password',
+          type: 'password',
+          templateOptions: {
+            label: 'Password Field (with custom label)',
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/demo/src/app/examples/advanced/extending-field-types/app.module.ts
+++ b/demo/src/app/examples/advanced/extending-field-types/app.module.ts
@@ -1,0 +1,33 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
+import { MatTabsModule } from '@angular/material/tabs';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTabsModule,
+    FormlyBootstrapModule,
+    FormlyModule.forRoot({
+      types: [
+        {
+          name: 'password',
+          extends: 'input',
+          defaultOptions: {
+            templateOptions: {
+              type: 'password',
+              label: 'Default Password Field',
+            },
+          },
+        },
+      ],
+    }),
+  ],
+  declarations: [AppComponent],
+})
+export class AppModule {}

--- a/demo/src/app/examples/advanced/extending-field-types/config.module.ts
+++ b/demo/src/app/examples/advanced/extending-field-types/config.module.ts
@@ -17,8 +17,8 @@ import { AppComponent } from './app.component';
             {
               title: 'Extending Field Types',
               description: `
-              This example demonstrates how to use the <code>extending<code> option when defining field types in the formly module. <br/>
-              The <code>password<code> field type is simply a normal <code>input<code> type with a predefined type and label.
+              This example demonstrates how to use the <code>extending</code> option when defining field types in the formly module. <br/>
+              The <code>password</code> field type is simply a normal <code>input</code> type with a predefined type and label.
             `,
               component: AppComponent,
               files: [

--- a/demo/src/app/examples/advanced/extending-field-types/config.module.ts
+++ b/demo/src/app/examples/advanced/extending-field-types/config.module.ts
@@ -1,0 +1,48 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [
+            {
+              title: 'Extending Field Types',
+              description: `
+              This example demonstrates how to use the <code>extending<code> option when defining field types in the formly module. <br/>
+              The <code>password<code> field type is simply a normal <code>input<code> type with a predefined type and label.
+            `,
+              component: AppComponent,
+              files: [
+                {
+                  file: 'app.component.html',
+                  content: require('!!highlight-loader?raw=true&lang=html!./app.component.html'),
+                  filecontent: require('!!raw-loader!./app.component.html'),
+                },
+                {
+                  file: 'app.component.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.component.ts'),
+                  filecontent: require('!!raw-loader!./app.component.ts'),
+                },
+                {
+                  file: 'app.module.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.module.ts'),
+                  filecontent: require('!!raw-loader!./app.module.ts'),
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]),
+  ],
+})
+export class ConfigModule {}

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -181,6 +181,11 @@ import { SharedModule } from '../shared';
                 loadChildren: () => import('./advanced/multi-step-form/config.module').then((m) => m.ConfigModule),
               },
               { path: 'tabs', loadChildren: () => import('./advanced/tabs/config.module').then((m) => m.ConfigModule) },
+              {
+                path: 'extending-field-types',
+                loadChildren: () =>
+                  import('./advanced/extending-field-types/config.module').then((m) => m.ConfigModule),
+              },
             ],
           },
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update: A new example that shows how to add a new field type that extends another.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**

![image](https://user-images.githubusercontent.com/34165455/128036732-7393dc30-4bb5-4181-8c9c-9101c53a1f03.png)

