### PR TITLE
docs(guides): add custom extension guide

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -21,6 +21,7 @@ export class AppComponent {
         { path: '/guide/expression-properties', title: 'Formly Expressions' },
         { path: '/guide/custom-formly-field', title: 'Custom Templates' },
         { path: '/guide/custom-formly-wrapper', title: 'Custom Wrapper' },
+        { path: '/guide/custom-formly-extension', title: 'Custom Extension' },
       ],
     },
     {

--- a/demo/src/app/examples/advanced/i18n-alternative/translate.extension.ts
+++ b/demo/src/app/examples/advanced/i18n-alternative/translate.extension.ts
@@ -1,7 +1,7 @@
-import { FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyExtension, FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
 
-export class TranslateExtension {
+export class TranslateExtension implements FormlyExtension {
   constructor(private translate: TranslateService) {}
   prePopulate(field: FormlyFieldConfig) {
     const to = field.templateOptions || {};

--- a/demo/src/app/guides/custom-formly-extension.md
+++ b/demo/src/app/guides/custom-formly-extension.md
@@ -1,0 +1,100 @@
+# Custom Extensions
+
+Extensions are a versatile formly feature that allows you to implement cross-cutting functionality that can be applied to all of your fields.
+
+Internally, a lot of formly's logic is built on extensions, so understanding them can greatly increase the things you can do with formly. If you're looking for more resources and examples, check out these links:
+- [Egghead.io courses on extensions](https://egghead.io/lessons/angular-implement-cross-cutting-functionality-with-angular-formly-extensions)
+- [Example: using an extension to internationalize forms](https://formly.dev/examples/advanced/i18n-alternative)
+- [Example: using an extension to include animations in forms](https://formly.dev/examples/other/hide-fields-with-animations)
+
+
+## Creating a Custom Extension
+
+Creating a custom extension is easy. The following example creates an extension that defines a default label if the `FormlyFieldConfig` doesn't define one itself.
+
+See live demo: [demo](https://stackblitz.com/edit/ngx-formly-ui-bootstrap-slzm3p?file=src/app/app.component.ts)
+
+  1. Define the custom extension:
+
+    There are two options when writing an extension:
+    - Create an object of type `FormlyExtension`.
+    - Create a class implementing the interface `FormlyExtension`. Do this if your [extension comes with any dependencies](https://formly.dev/examples/advanced/i18n-alternative).
+    
+    For this simple example, we will choose the first option.
+
+    ```typescript
+    // default-label-extension.ts
+    import { FormlyExtension } from '@ngx-formly/core';
+
+    export const defaultLabelExtension: FormlyExtension = {
+      prePopulate(field): void {
+        if (field.templateOptions?.label) {
+          return;
+        }
+        field.templateOptions = {
+          ...field.templateOptions,
+          label: 'Default Label'
+        }
+      },
+    };
+    ```
+
+    > Note: `FormlyExtension` allows you to define up to three methods that will be called in this order during the form construction process:
+    > `prePopulate`, `onPopulate` and `postPopulate`
+
+  2. Register the custom extension in `NgModule` declaration:
+    ```typescript
+    // app.module.ts
+    import { NgModule } from '@angular/core';
+    import { BrowserModule } from '@angular/platform-browser';
+    import { ReactiveFormsModule } from '@angular/forms';
+
+    import { FormlyModule } from '@ngx-formly/core';
+    import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
+
+    import { AppComponent } from './app.component';
+    import { defaultLabelExtension } from './default-label-extension';
+
+    @NgModule({
+      imports: [
+        BrowserModule,
+        ReactiveFormsModule,
+        FormlyBootstrapModule,
+        FormlyModule.forRoot({
+          extensions: [
+            {
+              name: 'default-label',
+              extension: defaultLabelExtension
+            }
+          ]
+        })
+      ],
+      declarations: [AppComponent],
+      bootstrap: [AppComponent]
+    })
+    export class AppModule {}
+    ```
+
+    `extensions: [ ... ]` is where we define which extensions should be active.
+
+  3. Create a custom FormlyFieldConfig and see the magic happen:
+
+    ```typescript
+     fields: FormlyFieldConfig[] = [
+      {
+        key: 'input',
+        type: 'input',
+        templateOptions: {
+          label: 'Basic Input'
+        }
+      },
+      {
+        key: 'input2',
+        type: 'input'
+      }
+    ];
+
+    ```
+
+  Look at the demo to see that the default label has been automatically added to the field.
+

--- a/demo/src/app/guides/guides.component.ts
+++ b/demo/src/app/guides/guides.component.ts
@@ -14,6 +14,7 @@ export class GuidesComponent implements OnInit {
     'getting-started': require('!!raw-loader!!highlight-loader!markdown-loader!./introduction.md'),
     'properties-options': require('!!raw-loader!!highlight-loader!markdown-loader!./properties-options.md'),
     'custom-formly-field': require('!!raw-loader!!highlight-loader!markdown-loader!./custom-formly-field.md'),
+    'custom-formly-extension': require('!!raw-loader!!highlight-loader!markdown-loader!./custom-formly-extension.md'),
     'custom-formly-wrapper': require('!!raw-loader!!highlight-loader!markdown-loader!./custom-formly-wrapper.md'),
     validation: require('!!raw-loader!!highlight-loader!markdown-loader!./validation.md'),
     'expression-properties': require('!!raw-loader!!highlight-loader!markdown-loader!./expression-properties.md'),


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR adds a guide for one of the remaining big formly features: extensions.
In addition, I have updated an example for clarity.



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**

![image](https://user-images.githubusercontent.com/34165455/128053315-a686f145-75a8-4c3b-97e2-56654b82f23d.png)


**Other information**:
