### PR TITLE
Emit event on expression change

### DIFF
--- a/src/core/src/lib/extensions/field-expression/field-expression.spec.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
 import { Component } from '@angular/core';
 import { Subject, of, BehaviorSubject } from 'rxjs';
@@ -556,6 +556,37 @@ describe('FieldExpressionExtension', () => {
         expect(fields[0].formControl.value).toEqual('test');
       });
     });
+
+    fdescribe('model changes', () => {
+      it('should emit formControl value changes', () => {
+        const fields: FormlyFieldConfig[] = [
+          {
+            key: 'text',
+            type: 'input',
+            expressionProperties: {
+              'model.text2': "model.text",
+            },
+          },
+          {
+            key: 'text2',
+            type: 'input',
+          }
+        ];
+        const model: any = {};
+        const options = {};
+
+        builder.buildForm(form, fields, model, options);
+        expect(fields[1].formControl.value).toEqual(null);
+        const spy = jasmine.createSpy('formControl valueChanges spy');
+        fields[1].formControl.valueChanges.subscribe(spy)
+        expect(spy).not.toHaveBeenCalled();
+        
+        model.text = 'test';
+        builder.buildForm(form, fields, model, options);
+
+        expect(spy).toHaveBeenCalledWith('test');
+      })
+    })
 
     it('should supports array notation in expression property', () => {
       const fields: FormlyFieldConfig[] = [

--- a/src/core/src/lib/extensions/field-expression/field-expression.spec.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed, inject} from '@angular/core/testing';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
 import { Component } from '@angular/core';
 import { Subject, of, BehaviorSubject } from 'rxjs';
@@ -564,13 +564,13 @@ describe('FieldExpressionExtension', () => {
             key: 'text',
             type: 'input',
             expressionProperties: {
-              'model.text2': "model.text",
+              'model.text2': 'model.text',
             },
           },
           {
             key: 'text2',
             type: 'input',
-          }
+          },
         ];
         const model: any = {};
         const options = {};
@@ -578,15 +578,15 @@ describe('FieldExpressionExtension', () => {
         builder.buildForm(form, fields, model, options);
         expect(fields[1].formControl.value).toEqual(null);
         const spy = jasmine.createSpy('formControl valueChanges spy');
-        fields[1].formControl.valueChanges.subscribe(spy)
+        fields[1].formControl.valueChanges.subscribe(spy);
         expect(spy).not.toHaveBeenCalled();
-        
+
         model.text = 'test';
         builder.buildForm(form, fields, model, options);
 
         expect(spy).toHaveBeenCalledWith('test');
-      })
-    })
+      });
+    });
 
     it('should supports array notation in expression property', () => {
       const fields: FormlyFieldConfig[] = [

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -300,7 +300,7 @@ export class FieldExpressionExtension implements FormlyExtension {
         && !(isNullOrUndefined(control.value) && isNullOrUndefined(value))
         && control.value !== value
       ) {
-        control.patchValue(value, { emitEvent: false });
+        control.patchValue(value);
       }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug Fix

**What is the current behavior? (You can also link to an open issue here)**

Currently, if an implementing library solely relys on formControl.valueChanges to get values from the model, when an expression change occurs for the model, the data is not emitted.

**What is the new behavior (if this is a feature change)?**

Expression changes on model now emit events

**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
