### PR TITLE
Fix typo in 6.0 upgrade documentation

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -27,7 +27,7 @@ UPGRADE FROM 5.0 to 6.0
   ```patch
     showLoader() {
   -   field.templateOptions.loading = true
-  +   field.templateOptions.loading = {
+  +   field.templateOptions = {
   +     ...field.templateOptions,
   +     loading: true
   +   };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix a slight issue in the code sample in the 6.0 upgrade documentation. The assignment should be on `field.templateOptions`, not `field.templateOptions.loading`.

**What is the current behavior? (You can also link to an open issue here)**

The current documentation is incorrect. See above.

**What is the new behavior (if this is a feature change)?**

No new behaviour.

**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
