### PR TITLE
fix(upgrade): update incorrect spread operator in upgrade docs

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -27,7 +27,7 @@ UPGRADE FROM 5.0 to 6.0
   ```patch
     showLoader() {
   -   field.templateOptions.loading = true
-  +   field.templateOptions.loading = {
+  +   field.templateOptions = {
   +     ...field.templateOptions,
   +     loading: true
   +   };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Documentation update - fix typo: `field.templateOptions.loading = ...` should read `field.templateOptions = ...` in the UPGRADE-6.0.md docs.

**What is the current behavior? (You can also link to an open issue here)**

n/a

**What is the new behavior (if this is a feature change)?**

n/a

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
