### PR TITLE
docs: change site title based on the opened page

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,13 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
+import { Title } from '@angular/platform-browser';
+import { NavigationEnd, Router } from '@angular/router';
 
 @Component({
   selector: 'formly-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   isSmallDevice$ = this.breakpointObserver.observe([Breakpoints.XSmall]).pipe(map((result) => result.matches));
 
   menu = [
@@ -102,5 +104,22 @@ export class AppComponent {
     },
   ];
 
-  constructor(private breakpointObserver: BreakpointObserver) {}
+  private documentTitle$ = this.router.events.pipe(
+    filter((event) => event instanceof NavigationEnd),
+    map((event: NavigationEnd) => event.urlAfterRedirects),
+    map((currentUrl) => {
+      const sidebarLinks = this.menu.flatMap((group) => group.links);
+      const activeLink = sidebarLinks.find((link) => link.path === currentUrl);
+      const title = activeLink?.title;
+
+      const baseTitle = 'Angular Formly';
+      return title ? `${baseTitle} - ${title}` : baseTitle;
+    }),
+  );
+
+  constructor(private breakpointObserver: BreakpointObserver, private router: Router, private titleService: Title) {}
+
+  ngOnInit(): void {
+    this.documentTitle$.subscribe((title) => this.titleService.setTitle(title));
+  }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs: this PR aims to enhance the demo site's usability by changing the site's title for different pages.

When someone has multiple tabs open for the demo site, it's not clear which tab corresponds to which page. With this change the tab's content becomes unambiguous.

**What is the current behavior? (You can also link to an open issue here)**

Every page has the same title:

![image](https://user-images.githubusercontent.com/31937175/147857876-0b84cf90-f3ae-4e75-a531-7749f6c5bc1b.png)


**What is the new behavior (if this is a feature change)?**

Each page has a different title based on it's sidebar link's text (the first tab shows the index page):

![image](https://user-images.githubusercontent.com/31937175/147857879-acbebc34-b7b1-459c-8467-224f6f4d0909.png)


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

