### PR TITLE
Support input type (text or tel) for datepicker

### DIFF
--- a/src/ui/material/datepicker/src/datepicker.type.ts
+++ b/src/ui/material/datepicker/src/datepicker.type.ts
@@ -69,7 +69,7 @@ export class FormlyDatepickerTypeComponent extends FieldType implements AfterVie
     this.to[this.to.datepickerOptions.datepickerTogglePosition] = this.datepickerToggle;
     
     if (!['text', 'tel'].includes(this.to.type)) {
-      this.type.to = "text";
+      this.to.type = "text";
     }
   }
 }

--- a/src/ui/material/datepicker/src/datepicker.type.ts
+++ b/src/ui/material/datepicker/src/datepicker.type.ts
@@ -7,6 +7,7 @@ import { FieldType } from '@ngx-formly/material/form-field';
     <input
       matInput
       [id]="id"
+      [type]="to.type"
       [errorStateMatcher]="errorStateMatcher"
       [formControl]="formControl"
       [matDatepicker]="picker"
@@ -47,6 +48,7 @@ export class FormlyDatepickerTypeComponent extends FieldType implements AfterVie
 
   defaultOptions = {
     templateOptions: {
+      type: 'text',
       datepickerOptions: {
         startView: 'month',
         datepickerTogglePosition: 'suffix',
@@ -65,5 +67,9 @@ export class FormlyDatepickerTypeComponent extends FieldType implements AfterVie
   ngAfterViewInit() {
     super.ngAfterViewInit();
     this.to[this.to.datepickerOptions.datepickerTogglePosition] = this.datepickerToggle;
+    
+    if (!['text', 'tel'].includes(this.to.type)) {
+      this.type.to = "text";
+    }
   }
 }


### PR DESCRIPTION
**Improvement:** adding support for input type in datepicker.ts by using existing implementation. This would allow users to set the type to "text" or "tel" based on their requirements. A more common use case is to set the type to "tel" to open the numeric keyboard on mobile devices.

**Current behavior:** there is no way to change the input type (defaulting it to text).

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)