### PR TITLE
feat(core): add showValid configuration extra

### DIFF
--- a/demo/src/app/app.menu.json
+++ b/demo/src/app/app.menu.json
@@ -63,6 +63,7 @@
           { "path": "/examples/validation/async-validation-update-on", "label": "Async validation and `updateOn`" },
           { "path": "/examples/validation/matching-two-fields", "label": "Matching Two Fields" },
           { "path": "/examples/validation/force-show-error", "label": "Force showing error state" },
+          { "path": "/examples/validation/show-valid", "label": "Control when to show validation " },
           { "path": "/examples/validation/toggle-required", "label": "Toggle required field" },
           { "path": "/examples/validation/disable-submit-button", "label": "Disable submit button" }
         ]

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -92,6 +92,10 @@ import { SharedModule } from '../shared';
                 loadChildren: () => import('./validation/force-show-error/config.module').then((m) => m.ConfigModule),
               },
               {
+                path: 'show-valid',
+                loadChildren: () => import('./validation/show-valid/config.module').then((m) => m.ConfigModule),
+              },
+              {
                 path: 'toggle-required',
                 loadChildren: () => import('./validation/toggle-required/config.module').then((m) => m.ConfigModule),
               },

--- a/demo/src/app/examples/validation/show-valid/app.component.html
+++ b/demo/src/app/examples/validation/show-valid/app.component.html
@@ -1,0 +1,4 @@
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+  <button type="submit" class="btn btn-primary submit-button">Submit</button>
+</form>

--- a/demo/src/app/examples/validation/show-valid/app.component.ts
+++ b/demo/src/app/examples/validation/show-valid/app.component.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  form = new FormGroup({});
+  options: FormlyFormOptions = {
+    showValid: (field) => {
+      return (
+        this.model.showValid &&
+        field.formControl.valid &&
+        (field.formControl?.touched || field.options.parentForm?.submitted || !!field.field.validation?.show)
+      );
+    },
+  };
+
+  model = {
+    showValid: false,
+  };
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'req',
+      type: 'input-adjusted',
+      templateOptions: {
+        type: 'input',
+        label: 'Required Input',
+        required: true,
+      },
+    },
+    {
+      key: 'showValid',
+      type: 'checkbox',
+      templateOptions: {
+        label: 'Show valid feedback for form?',
+      },
+    },
+  ];
+
+  submit() {
+    if (this.form.valid) {
+      alert(JSON.stringify(this.model));
+    }
+  }
+}

--- a/demo/src/app/examples/validation/show-valid/app.module.ts
+++ b/demo/src/app/examples/validation/show-valid/app.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
+
+import { AppComponent } from './app.component';
+import { FormlyFieldInputAdjusted } from './form-field-adjusted.wrapper';
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormlyBootstrapModule,
+    FormlyModule.forRoot({
+      types: [
+        {
+          name: 'input-adjusted',
+          component: FormlyFieldInputAdjusted,
+        },
+      ],
+    }),
+  ],
+  declarations: [AppComponent, FormlyFieldInputAdjusted],
+})
+export class AppModule {}

--- a/demo/src/app/examples/validation/show-valid/config.module.ts
+++ b/demo/src/app/examples/validation/show-valid/config.module.ts
@@ -1,0 +1,53 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [
+            {
+              title: 'Show valid feedback',
+              description: `
+              Using the configurable <code>showValid</code> extra you can control when to show valid feedback, similar to <code>showError</code>. </br>
+              This can be configured centrally in the <code>FormlyModule</code> or via the <code>options</code> input.
+            `,
+              component: AppComponent,
+              files: [
+                {
+                  file: 'app.component.html',
+                  content: require('!!highlight-loader?raw=true&lang=html!./app.component.html'),
+                  filecontent: require('!!raw-loader!./app.component.html'),
+                },
+                {
+                  file: 'app.component.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.component.ts'),
+                  filecontent: require('!!raw-loader!./app.component.ts'),
+                },
+                {
+                  file: 'app.module.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.module.ts'),
+                  filecontent: require('!!raw-loader!./app.module.ts'),
+                },
+                {
+                  file: 'form-field-adjusted.wrapper.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./form-field-adjusted.wrapper.ts'),
+                  filecontent: require('!!raw-loader!./form-field-adjusted.wrapper.ts'),
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]),
+  ],
+})
+export class ConfigModule {}

--- a/demo/src/app/examples/validation/show-valid/form-field-adjusted.wrapper.ts
+++ b/demo/src/app/examples/validation/show-valid/form-field-adjusted.wrapper.ts
@@ -1,0 +1,33 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-field-input',
+  template: `
+    <input
+      *ngIf="type !== 'number'; else numberTmp"
+      [type]="type"
+      [formControl]="formControl"
+      class="form-control"
+      [formlyAttributes]="field"
+      [class.is-invalid]="showError"
+      [class.is-valid]="showValid"
+    />
+    <ng-template #numberTmp>
+      <input
+        type="number"
+        [formControl]="formControl"
+        class="form-control"
+        [formlyAttributes]="field"
+        [class.is-invalid]="showError"
+        [class.is-valid]="showValid"
+      />
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormlyFieldInputAdjusted extends FieldType<FieldTypeConfig> {
+  get type() {
+    return this.to.type || 'text';
+  }
+}

--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -76,6 +76,9 @@ export class CoreExtension implements FormlyExtension {
     if (!options.showError) {
       options.showError = this.config.extras.showError;
     }
+    if (!options.showValid) {
+      options.showValid = this.config.extras.showValid;
+    }
 
     if (!options.fieldChanges) {
       defineHiddenProp(options, 'fieldChanges', new Subject<FormlyValueChangeEvent>());

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -68,6 +68,7 @@ export interface ConfigOption {
   extras?: {
     immutable?: boolean;
     showError?: (field: FieldType) => boolean;
+    showValid?: (field: FieldType) => boolean;
 
     /**
      * Defines the option which formly rely on to check field expression properties.

--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -256,6 +256,7 @@ export interface FormlyFormOptions {
   formState?: any;
   fieldChanges?: Subject<FormlyValueChangeEvent>;
   showError?: (field: FieldType) => boolean;
+  showValid?: (field: FieldType) => boolean;
   build?: (field?: FormlyFieldConfig) => FormlyFieldConfig;
   checkExpressions?: (field: FormlyFieldConfig) => void;
   detectChanges?: (field: FormlyFieldConfig) => void;

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -42,6 +42,9 @@ export class FormlyConfig {
         (field.formControl?.touched || field.options.parentForm?.submitted || !!field.field.validation?.show)
       );
     },
+    showValid(field: FieldType) {
+      return field.formControl?.touched || field.options.parentForm?.submitted || !!field.field.validation?.show;
+    },
   };
   extensions: { [name: string]: FormlyExtension } = {};
   presets: { [name: string]: FormlyFieldConfig | FormlyFieldConfigPresetProvider } = {};

--- a/src/core/src/lib/templates/field.type.ts
+++ b/src/core/src/lib/templates/field.type.ts
@@ -50,6 +50,10 @@ export abstract class FieldType<F extends FormlyFieldConfig = FormlyFieldConfig>
     return this.options.showError(this);
   }
 
+  get showValid(): boolean {
+    return this.options.showValid(this);
+  }
+
   get id(): string {
     return this.field.id;
   }


### PR DESCRIPTION
THIS IS A DRAFT PR

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This is a feature to add a centrally configurable `showValid` extra that types and wrappers can read to configure their validation display behavior.

**What is the current behavior? (You can also link to an open issue here)**
Currently, it is possible to configure when to show errors using `showError`. This is sometimes too limited as explained in #2728.


**What is the new behavior (if this is a feature change)?**
Now, an additional function (`showValid`) is available to separately control when to show valid feedback (positive validation) messages and styling. This is not used throughout formly itself but e.g. bootstraps supports it and it is very useful to have a configurable analogue in the module

@aitboudad this is what I had in mind, it's a pretty small change in the core functionality. The custom type in the provided example is adjusted to show what I mean.
Of course, this is a draft PR so if you still think this is a useful feature (even though it doesn't address your concerns about #2385 ) I will proceed and flesh it out with tests and see how to fix the change detection in the example.
I'm also willing to work on a more general solution and probably more complex solution for more fine-grained control over validation. In that case just reject this PR and we can discuss how to proceed.


**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
