### PR TITLE
feat(core): introduce priority to sort extensions

### DIFF
--- a/demo/src/app/guides/custom-formly-extension.md
+++ b/demo/src/app/guides/custom-formly-extension.md
@@ -98,3 +98,22 @@ See live demo: [demo](https://stackblitz.com/edit/ngx-formly-ui-bootstrap-slzm3p
 
   Look at the demo to see that the default label has been automatically added to the field.
 
+## Extension priority
+When registering an extension with the `FormlyModule`, you can provide an additional `priority` property of type `number`.
+This will be used to change the order in which extensions are executed. If you have multiple extensions that change the same properties of a `FormlyFieldConfig`, you can use this to ensure they are executed in the correct order. Extensions with higher `priority` values will be executed later.
+
+If you don't provide a `priority` option, a default value of `1` will be used. <br/>
+Formly's own internal extensions have a priority of `-1`.
+
+```typescript
+  FormlyModule.forRoot({
+    extensions: [
+      {
+        name: 'default-label',
+        extension: defaultLabelExtension,
+        priority: 3
+      }
+    ]
+  })
+```
+

--- a/src/core/src/lib/core.module.ts
+++ b/src/core/src/lib/core.module.ts
@@ -23,10 +23,10 @@ export function defaultFormlyConfig(config: FormlyConfig): ConfigOption {
       { name: 'formly-template', component: FormlyTemplateType },
     ],
     extensions: [
-      { name: 'core', extension: new CoreExtension(config) },
-      { name: 'field-validation', extension: new FieldValidationExtension(config) },
-      { name: 'field-form', extension: new FieldFormExtension() },
-      { name: 'field-expression', extension: new FieldExpressionExtension() },
+      { name: 'core', extension: new CoreExtension(config), priority: -1 },
+      { name: 'field-validation', extension: new FieldValidationExtension(config), priority: -1 },
+      { name: 'field-form', extension: new FieldFormExtension(), priority: -1 },
+      { name: 'field-expression', extension: new FieldExpressionExtension(), priority: -1 },
     ],
   };
 }

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -5,6 +5,8 @@ import { Observable } from 'rxjs';
 
 /** @experimental */
 export interface FormlyExtension<F extends FormlyFieldConfig = FormlyFieldConfig> {
+  priority?: number;
+
   prePopulate?(field: F): void;
   onPopulate?(field: F): void;
   postPopulate?(field: F): void;
@@ -39,6 +41,7 @@ export interface ValidatorOption {
 export interface ExtensionOption {
   name: string;
   extension: FormlyExtension;
+  priority?: number;
 }
 
 export interface ValidationMessageOption {

--- a/src/core/src/lib/services/formly.builder.spec.ts
+++ b/src/core/src/lib/services/formly.builder.spec.ts
@@ -58,6 +58,88 @@ describe('FormlyFormBuilder service', () => {
     expect(spy.mock.calls).toEqual([['prePopulate'], ['onPopulate'], ['postPopulate']]);
   });
 
+  it('should call extensions in default order during build call', () => {
+    const spy = jest.fn();
+    const core = {
+      prePopulate: () => spy('prePopulateCore'),
+      onPopulate: () => spy('onPopulateCore'),
+      postPopulate: () => spy('postPopulateCore'),
+    };
+    const extension1 = {
+      prePopulate: () => spy('prePopulate1'),
+      onPopulate: () => spy('onPopulate1'),
+      postPopulate: () => spy('postPopulate1'),
+    };
+    const extension2 = {
+      prePopulate: () => spy('prePopulate2'),
+      onPopulate: () => spy('onPopulate2'),
+      postPopulate: () => spy('postPopulate2'),
+    };
+
+    const builder = createBuilder({
+      extensions: [
+        { name: 'core', extension: core, priority: -1 },
+        { name: 'extension1', extension: extension1 },
+        { name: 'extension2', extension: extension2 },
+      ],
+    });
+
+    builder.build({});
+
+    expect(spy.mock.calls).toEqual([
+      ['prePopulateCore'],
+      ['prePopulate1'],
+      ['prePopulate2'],
+      ['onPopulateCore'],
+      ['onPopulate1'],
+      ['onPopulate2'],
+      ['postPopulateCore'],
+      ['postPopulate1'],
+      ['postPopulate2'],
+    ]);
+  });
+
+  it('should call extensions in modified order during build call', () => {
+    const spy = jest.fn();
+    const core = {
+      prePopulate: () => spy('prePopulateCore'),
+      onPopulate: () => spy('onPopulateCore'),
+      postPopulate: () => spy('postPopulateCore'),
+    };
+    const extension1 = {
+      prePopulate: () => spy('prePopulate1'),
+      onPopulate: () => spy('onPopulate1'),
+      postPopulate: () => spy('postPopulate1'),
+    };
+    const extension2 = {
+      prePopulate: () => spy('prePopulate2'),
+      onPopulate: () => spy('onPopulate2'),
+      postPopulate: () => spy('postPopulate2'),
+    };
+
+    const builder = createBuilder({
+      extensions: [
+        { name: 'core', extension: core, priority: -1 },
+        { name: 'extension1', extension: extension1, priority: 10 },
+        { name: 'extension2', extension: extension2 },
+      ],
+    });
+
+    builder.build({});
+
+    expect(spy.mock.calls).toEqual([
+      ['prePopulateCore'],
+      ['prePopulate2'],
+      ['prePopulate1'],
+      ['onPopulateCore'],
+      ['onPopulate2'],
+      ['onPopulate1'],
+      ['postPopulateCore'],
+      ['postPopulate2'],
+      ['postPopulate1'],
+    ]);
+  });
+
   it('should build nested field', () => {
     const extension = { onPopulate: () => {} };
     jest.spyOn(extension, 'onPopulate');


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
core feature


**What is the current behavior? (You can also link to an open issue here)**
Currently, there is no way to specifically order extensions. It will happen implicitly, depending on the order in which they are defined. This quickly becomes intransparent when you enforce alphabetic sorting or define extensions throughout multiple modules where the loading order is not clear.

**What is the new behavior (if this is a feature change)?**
This PR introduces an optional `priority` property to the `FormlyExtension` type that enables you to control this behavior. Lower numbers are processed first, with formly's own extensions all get a value of `-1`. Default `priority` is `1`.

Let me know what you think of this feature and if you like it, I will write documentation, an example and everything to make it complete.



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
