### PR TITLE
build: update build script for Windows

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -5,8 +5,8 @@ const mainPkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const distDir = 'dist/@ngx-formly';
 
 // cleanup
-exec(`rm -rf ${distDir}`);
-exec(`mkdir -p ${distDir}`);
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
 
 PACKAGES.map((name) => {
   // build package
@@ -17,7 +17,9 @@ PACKAGES.map((name) => {
   );
 
   const pkgDir = `${distDir}/${name}`;
-  exec(`cp README.md ${pkgDir}`);
+  fs.copyFile('README.md', `${pkgDir}/README.md`, (err) => {
+    if (err) throw err;
+  });
 
   // update `FORMLY-VERSION` in package.json for all sub-packages
   const pkgPath = `${pkgDir}/package.json`;

--- a/build/schematics.ts
+++ b/build/schematics.ts
@@ -1,6 +1,6 @@
-import { exec } from './util';
+import { copyDirSync, exec } from './util';
 
 // build
 exec('cd src/schematics && npm run build');
 // copy to dist
-exec('cp -r src/schematics dist/@ngx-formly/schematics');
+copyDirSync('src/schematics', 'dist/@ngx-formly/schematics');

--- a/build/util.ts
+++ b/build/util.ts
@@ -1,4 +1,6 @@
 import { execSync, ExecSyncOptions } from 'child_process';
+import * as fs from 'fs';
+import { join } from 'path';
 
 export const PACKAGES = [
   'core',
@@ -16,4 +18,16 @@ export const PACKAGES = [
 
 export function exec(cmd: string, options: ExecSyncOptions = { stdio: 'inherit' }) {
   return execSync(cmd, options);
+}
+
+export function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  let entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (let entry of entries) {
+    let srcPath = join(src, entry.name);
+    let destPath = join(dest, entry.name);
+
+    entry.isDirectory() ? copyDirSync(srcPath, destPath) : fs.copyFileSync(srcPath, destPath);
+  }
 }


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
Because they rely on linux/unix command line tools, the build scripts previously didn't work for windows.


**What is the new behavior (if this is a feature change)?**
Now, the functionality is reimplemented using Node.js functions that work in any environment.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
