### PR TITLE
refactor: remove experimental markers

### DIFF
--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -15,7 +15,6 @@ import {
 } from '../../utils';
 import { Subject } from 'rxjs';
 
-/** @experimental */
 export class CoreExtension implements FormlyExtension {
   private formId = 0;
   constructor(private config: FormlyConfig) {}

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -16,7 +16,6 @@ import { FormlyExtension } from '../../models';
 import { unregisterControl, registerControl, updateValidity } from '../field-form/utils';
 import { FormArray } from '@angular/forms';
 
-/** @experimental */
 export class FieldExpressionExtension implements FormlyExtension {
   onPopulate(field: FormlyFieldConfigCache) {
     if (field._expressions) {

--- a/src/core/src/lib/extensions/field-form/field-form.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.ts
@@ -11,7 +11,6 @@ import { getFieldValue, defineHiddenProp, hasKey } from '../../utils';
 import { registerControl, findControl, updateValidity } from './utils';
 import { of } from 'rxjs';
 
-/** @experimental */
 export class FieldFormExtension implements FormlyExtension {
   private root: FormlyFieldConfigCache;
   prePopulate(field: FormlyFieldConfigCache) {

--- a/src/core/src/lib/extensions/field-validation/field-validation.ts
+++ b/src/core/src/lib/extensions/field-validation/field-validation.ts
@@ -6,7 +6,6 @@ import { updateValidity } from '../field-form/utils';
 import { isObservable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-/** @experimental */
 export class FieldValidationExtension implements FormlyExtension {
   constructor(private config: FormlyConfig) {}
 

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -3,7 +3,6 @@ import { FieldType } from './../templates/field.type';
 import { FormlyFieldConfig } from './fieldconfig';
 import { Observable } from 'rxjs';
 
-/** @experimental */
 export interface FormlyExtension<F extends FormlyFieldConfig = FormlyFieldConfig> {
   priority?: number;
 


### PR DESCRIPTION
What is the current behavior? (You can also link to an open issue here)**
Currently, the `FormlyExtension` type and the core extensions are marked as experimental. 
Extensions have been released for over 3 years now and have a prominent place in the docs. It's probably time to make them official for v6, dont' you agree @aitboudad?


**What is the new behavior (if this is a feature change)?**
Experimental markers are removed.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
