### PR TITLE
feat(json-schema): rely on minItems to pre-populate array default value

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -374,6 +374,15 @@ describe('Service: FormlyJsonschema', () => {
         expect(minItemsValidator(new FormControl([1, 2, 3]))).toBeTrue();
       });
 
+      it('minItems: should set default value', () => {
+        const numSchema: JSONSchema7 = {
+          type: 'array',
+          minItems: 2,
+        };
+        const config = formlyJsonschema.toFieldConfig(numSchema);
+        expect(config.defaultValue).toEqual([undefined, undefined]);
+      });
+
       it('should support maxItems', () => {
         const numSchema: JSONSchema7 = {
           type: 'array',

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -296,6 +296,10 @@ export class FormlyJsonschema {
             'minItems',
             ({ value }: AbstractControl) => isEmpty(value) || value.length >= schema.minItems,
           );
+
+          if (schema.minItems > 0 && field.defaultValue === undefined) {
+            field.defaultValue = Array.from(new Array(schema.minItems));
+          }
         }
         if (schema.hasOwnProperty('maxItems')) {
           field.props.maxItems = schema.maxItems;


### PR DESCRIPTION
fix #3246