### PR TITLE
chore(core): remove unused tslint references

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,4 +13,3 @@ gulpfile.js
 karma.conf.js
 npm-debug.log
 tsconfig.json
-tslint.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,7 @@
     "lib": ["es2020", "dom"],
     "paths": {
       "@ngx-formly/*": ["src/*/src/private_api", "src/*/src/public_api", "src/ui/*/src/public_api"],
-      "@assets/*": ["demo/src/assets/*"],
-      "@ngx-formly/tslint": ["dist/ngx-formly/tslint/ngx-formly-tslint", "dist/ngx-formly/tslint"]
+      "@assets/*": ["demo/src/assets/*"]
     },
     "skipLibCheck": true
   },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
chore


**What is the current behavior? (You can also link to an open issue here)**
Even though TSLint is not used anymore, there is still some leftover configuration.


**What is the new behavior (if this is a feature change)?**
The leftover configuration has been removed.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] ~A unit test has been written for this change.~
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
