### PR TITLE
chore: update commitlint scopes to include "select"

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,9 +9,10 @@ module.exports = {
         'demo',
         'guides',
         'core',
+        'testing',
+        'select',
         'schematics',
         'json-schema',
-        'testing',
         'material',
         'bootstrap',
         'ionic',
@@ -19,14 +20,14 @@ module.exports = {
         'kendo',
         'ng-zorro-antd',
         'nativescript',
-      ]
+      ],
     ],
     'scope-empty': [1, 'never'],
     'scope-case': [2, 'always', 'lowerCase'],
     'type-enum': [
       2,
       'always',
-      ['build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'release', 'revert', 'style', 'test', 'chore']
-    ]
-  }
+      ['build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'release', 'revert', 'style', 'test', 'chore'],
+    ],
+  },
 };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

chore

**What is the current behavior? (You can also link to an open issue here)**

currently, if you work on the select feature, you have to use the scope "core"

**What is the new behavior (if this is a feature change)?**

"select" should be a scope just like "testing" because it is its own subpackage.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] ~A unit test has been written for this change.~
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
