### PR TITLE
refactor(core): export renamed FormlySelectOptions type

### DIFF
--- a/src/core/select/src/public_api.ts
+++ b/src/core/select/src/public_api.ts
@@ -1,2 +1,2 @@
 export { FormlySelectModule } from './select.module';
-export { FormlySelectOptionsPipe as ɵFormlySelectOptionsPipe } from './select-options.pipe';
+export { FormlySelectOptionsPipe as ɵFormlySelectOptionsPipe, FormlySelectOption } from './select-options.pipe';

--- a/src/core/select/src/select-options.pipe.ts
+++ b/src/core/select/src/select-options.pipe.ts
@@ -3,11 +3,11 @@ import { Observable, of as observableOf } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 
-interface ISelectOption {
+export interface FormlySelectOption {
   label: string;
   disabled?: boolean;
   value?: any;
-  group?: ISelectOption[];
+  group?: FormlySelectOption[];
 }
 
 type ITransformOption = {
@@ -19,7 +19,7 @@ type ITransformOption = {
 
 @Pipe({ name: 'formlySelectOptions' })
 export class FormlySelectOptionsPipe implements PipeTransform {
-  transform(options: any, field?: FormlyFieldConfig): Observable<ISelectOption[]> {
+  transform(options: any, field?: FormlyFieldConfig): Observable<FormlySelectOption[]> {
     if (!(options instanceof Observable)) {
       options = observableOf(options);
     }
@@ -27,10 +27,10 @@ export class FormlySelectOptionsPipe implements PipeTransform {
     return (options as Observable<any>).pipe(map((value) => this.transformOptions(value, field)));
   }
 
-  private transformOptions(options: any[], field?: FormlyFieldConfig): ISelectOption[] {
+  private transformOptions(options: any[], field?: FormlyFieldConfig): FormlySelectOption[] {
     const to = this.transformSelectProps(field);
 
-    const opts: ISelectOption[] = [];
+    const opts: FormlySelectOption[] = [];
     const groups: { [id: string]: number } = {};
 
     options.forEach((option) => {
@@ -54,7 +54,7 @@ export class FormlySelectOptionsPipe implements PipeTransform {
     return opts;
   }
 
-  private transformOption(option: any, props: ITransformOption): ISelectOption {
+  private transformOption(option: any, props: ITransformOption): FormlySelectOption {
     const group = props.groupProp(option);
     if (Array.isArray(group)) {
       return {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

refactor

**What is the current behavior? (You can also link to an open issue here)**

Currently, if you want to do something with the `ISelectOptions` that the select-options pipe returns, you have to copy it from formly.

**What is the new behavior (if this is a feature change)?**
Now, the public api of the select module contains a (renamed) `FormlySelectOptions` type.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] ~A unit test has been written for this change.~
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
