### PR TITLE
docs(preset): add preset to visible files in example

### DIFF
--- a/demo/src/app/examples/other/presets/config.module.ts
+++ b/demo/src/app/examples/other/presets/config.module.ts
@@ -34,6 +34,11 @@ import { AppComponent } from './app.component';
                   filecontent: require('!!raw-loader!./app.component.ts'),
                 },
                 {
+                  file: 'salutation.preset.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./salutation.preset.ts'),
+                  filecontent: require('!!raw-loader!./salutation.preset.ts'),
+                },
+                {
                   file: 'app.module.ts',
                   content: require('!!highlight-loader?raw=true&lang=typescript!./app.module.ts'),
                   filecontent: require('!!raw-loader!./app.module.ts'),


### PR DESCRIPTION
When I opened #3256 , there was a mistake in the example - salutation.preset.ts wasn't rendered.

I added it to the config module.