### PR TITLE
fix(core): fixed FieldArrayTypeConfig props declaration

### DIFF
--- a/src/core/src/lib/templates/field-array.type.ts
+++ b/src/core/src/lib/templates/field-array.type.ts
@@ -5,9 +5,9 @@ import { clone, assignFieldValue, getFieldValue, hasKey } from '../utils';
 import { FormlyFieldConfig, FormlyExtension } from '../models';
 import { registerControl, unregisterControl, findControl } from '../extensions/field-form/utils';
 
-export interface FieldArrayTypeConfig extends FormlyFieldConfig {
+export interface FieldArrayTypeConfig<T = FormlyFieldConfig['props']> extends FormlyFieldConfig<T> {
   formControl: FormArray;
-  props: NonNullable<Required<FormlyFieldConfig>['props']>;
+  props: NonNullable<T>;
 }
 
 @Directive()


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes #3341. 

**What is the current behavior? (You can also link to an open issue here)**
The FieldArrayTypeConfig type does not allow for a custom props value like FormlyFieldConfig does.

**What is the new behavior (if this is a feature change)?**
The FieldArrayTypeConfig type will now allow for a custom props value like FormlyFieldConfig does.

**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Other information**:

Looks like the types for this interface were overlooked in #3295.