### PR TITLE
fix(primeng): remove datepicker from main module

### DIFF
--- a/demo/src/app/ui/ui-primeng/config.module.ts
+++ b/demo/src/app/ui/ui-primeng/config.module.ts
@@ -5,17 +5,18 @@ import { CommonModule, debugFields } from '../common';
 
 import { AppComponent } from './app.component';
 import { FormlyPrimeNGModule } from '@ngx-formly/primeng';
-import { DatepickerExampleConfig } from './datepicker';
 import { InputExampleConfig } from '../common/input';
 import { CheckboxExampleConfig } from '../common/checkbox';
 import { RadioExampleConfig } from '../common/radio';
 import { TextareaExampleConfig } from '../common/textarea';
 import { SelectExampleConfig } from './select';
+import { DatepickerAppModule, DatepickerExampleConfig } from './datepicker';
 
 @NgModule({
   imports: [
     CommonModule,
     FormlyPrimeNGModule,
+    DatepickerAppModule,
     RouterModule.forChild([
       {
         path: '',
@@ -31,8 +32,8 @@ import { SelectExampleConfig } from './select';
                 TextareaExampleConfig,
                 CheckboxExampleConfig,
                 RadioExampleConfig,
-                DatepickerExampleConfig,
                 SelectExampleConfig,
+                DatepickerExampleConfig,
               ],
             },
           },

--- a/demo/src/app/ui/ui-primeng/datepicker/app.module.ts
+++ b/demo/src/app/ui/ui-primeng/datepicker/app.module.ts
@@ -2,8 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule } from '@ngx-formly/core';
-
-import { FormlyDatePickerModule } from '@ngx-formly/primeng/datepicker';
+import { FormlyDatepickerModule } from '@ngx-formly/primeng/datepicker';
 
 import { AppComponent } from './app.component';
 
@@ -15,7 +14,7 @@ import { AppComponent } from './app.component';
       validationMessages: [{ name: 'required', message: 'This field is required' }],
     }),
 
-    FormlyDatePickerModule,
+    FormlyDatepickerModule,
   ],
   declarations: [AppComponent],
 })

--- a/src/ui/primeng/datepicker/src/datepicker.module.ts
+++ b/src/ui/primeng/datepicker/src/datepicker.module.ts
@@ -25,4 +25,4 @@ import { FormlyFieldDatepicker } from './datepicker.type';
     }),
   ],
 })
-export class FormlyFieldDatepickerModule {}
+export class FormlyDatepickerModule {}

--- a/src/ui/primeng/datepicker/src/public_api.ts
+++ b/src/ui/primeng/datepicker/src/public_api.ts
@@ -1,7 +1,7 @@
-import { FormlyFieldDatepickerModule } from './datepicker.module';
+import { FormlyDatepickerModule } from './datepicker.module';
 export { FormlyDatepickerFieldConfig } from './datepicker.type';
 
-/** @deprecated use FormlyFieldDatepickerModule */
-const FormlyDatePickerModule = FormlyFieldDatepickerModule;
+/** @deprecated use FormlyDatepickerModule */
+const FormlyDatePickerModule = FormlyDatepickerModule;
 
-export { FormlyFieldDatepickerModule, FormlyDatePickerModule };
+export { FormlyDatepickerModule, FormlyDatePickerModule };

--- a/src/ui/primeng/src/lib/ui-primeng.module.ts
+++ b/src/ui/primeng/src/lib/ui-primeng.module.ts
@@ -5,7 +5,6 @@ import { FormlyTextAreaModule } from '@ngx-formly/primeng/textarea';
 import { FormlyRadioModule } from '@ngx-formly/primeng/radio';
 import { FormlyCheckboxModule } from '@ngx-formly/primeng/checkbox';
 import { FormlySelectModule } from '@ngx-formly/primeng/select';
-import { FormlyDatePickerModule } from '@ngx-formly/primeng/datepicker';
 
 @NgModule({
   imports: [
@@ -15,7 +14,6 @@ import { FormlyDatePickerModule } from '@ngx-formly/primeng/datepicker';
     FormlyRadioModule,
     FormlyCheckboxModule,
     FormlySelectModule,
-    FormlyDatePickerModule,
   ],
 })
 export class FormlyPrimeNGModule {}


### PR DESCRIPTION
fix #3339
BREAKING CHANGE: primeng `datepicker` type has been removed from `FormlyPrimeNGModule`, use `FormlyDatepickerModule` instead.

```ts
import { FormlyDatepickerModule } from '@ngx-formly/primeng/datepicker';

@NgModule({
  imports: [
      ...
      FormlyDatepickerModule,
  ],
})
export class AppModule {}
```