### PR TITLE
fix(core): set field arg required in expressions

### DIFF
--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -119,7 +119,7 @@ export interface FormlyFieldConfig<Props = FormlyFieldProps & { [additionalPrope
    * An object where the key is a property to be set on the main field config and the value is an expression used to assign that property.
    */
   expressions?: {
-    [property: string]: string | ((field?: FormlyFieldConfig) => any) | Observable<any>;
+    [property: string]: string | ((field: FormlyFieldConfig) => any) | Observable<any>;
   };
 
   /**


### PR DESCRIPTION
bug

key 'expressions' inside interface can get string or function. the function had interface 
`  expressions?: {
    [property: string]: string | ((field?: FormlyFieldConfig) => any) | Observable<any>;
  };`

the ? in the function arg tell ts that field can be also 'undefined' and 
a)it is not true.
b)it force you to add check that field is not undefined in the code because if not will be collison with the types..
 

**What is the new behavior (if this is a feature change)?**

i remove the ? from the function arg and now field cant be optional undefined

unit test  - didnt do. just manual QA
npm run build/lint  - no.


**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
