### PR TITLE
docs: correct deprecation message

### DIFF
--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -222,7 +222,7 @@ export interface FormlyFieldProps {
   minlength?: number;
 
   maxLength?: number;
-  /** @deprecated use `minLength` */
+  /** @deprecated use `maxLength` */
   maxlength?: number;
 
   pattern?: string | RegExp;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix typo in deprecation message: minLength -> maxLength.

**No behaviour changes**
