### PR TITLE
fix(demo): make sure guide links don't break for main.formly.dev

### DIFF
--- a/demo/src/app/guides/guides.component.ts
+++ b/demo/src/app/guides/guides.component.ts
@@ -1,4 +1,5 @@
-import { Component, ElementRef, Renderer2, OnInit } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, ElementRef, Renderer2, OnInit, Inject, PLATFORM_ID } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({
@@ -21,11 +22,22 @@ export class GuidesComponent implements OnInit {
     'formly-field-presets': require('!!raw-loader!!highlight-loader!markdown-loader!docs/formly-field-presets.md'),
   };
 
-  constructor(private renderer: Renderer2, private route: ActivatedRoute, private elementRef: ElementRef) {}
+  constructor(
+    private renderer: Renderer2,
+    private route: ActivatedRoute,
+    private elementRef: ElementRef,
+    @Inject(PLATFORM_ID) private platformId: string,
+  ) {}
 
   ngOnInit() {
+    console.log(window.location.origin);
+
     this.route.params.subscribe(({ id }) => {
-      this.renderer.setProperty(this.elementRef.nativeElement, 'innerHTML', this.contents[id].default);
+      let content: string = this.contents[id].default;
+      if (isPlatformBrowser(this.platformId) && window.location.origin === 'https://main.formly.dev') {
+        content = content.replace('https://formly.dev', 'https://main.formly.dev');
+      }
+      this.renderer.setProperty(this.elementRef.nativeElement, 'innerHTML', content);
     });
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

fix(demo)

**What is the current behavior? (You can also link to an open issue here)**

Currently, guide links are hardcoded to point to `https://formly.dev`. If you check out the main branch docs at `https://main.formly.dev`, these links sometimes don't work because the document doesn't exist in the latest release yet.

**What is the new behavior (if this is a feature change)?**
Now, all guide links containing `https://formly.dev` are replaced with the same link to `https://main.formly.dev` while you're browsing `https://main.formly.dev`.


----------
**This is just a quick fix**. To provide a more general solution, it could be feasible to replace all links (guides, examples etc) at build/deploy time or make a solution to provide relative links instead of absolute paths to `https://formly.dev`.

Maybe this could work by replacing the simple `require` calls with a custom function that loads a file and generates correct absolute paths according to the current origin like this: 

```typescript
contents: { [id: string]: any } = {
    'getting-started': loadDocs('!!raw-loader!!highlight-loader!markdown-loader!docs/getting-started.md'),
    ...
  };
```
(add something similar for the examples as well)
=> this would also generate correct paths for local development which is a plus.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
