### PR TITLE
fix(json-schema): retrieve other field value from f.model

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -589,8 +589,8 @@ describe('Service: FormlyJsonschema', () => {
 
             const config = formlyJsonschema.toFieldConfig(schema).fieldGroup;
             const hideExpr = config[1].expressions.hide as any;
-            expect(hideExpr({ credit_card: null })).toBeTrue();
-            expect(hideExpr({ credit_card: 121223233 })).toBeFalse();
+            expect(hideExpr({ model: { credit_card: null } })).toBeTrue();
+            expect(hideExpr({ model: { credit_card: 121223233 } })).toBeFalse();
           });
           it('should display extended schema with oneOf', () => {
             const schema: JSONSchema7 = {
@@ -621,12 +621,12 @@ describe('Service: FormlyJsonschema', () => {
 
             const [, opt1Field, opt2Field] = formlyJsonschema.toFieldConfig(schema).fieldGroup;
             const opt1HideExpr = opt1Field.expressions.hide as any;
-            expect(opt1HideExpr({ state: true })).toBeFalse();
-            expect(opt1HideExpr({ state: false })).toBeTrue();
+            expect(opt1HideExpr({ model: { state: true } })).toBeFalse();
+            expect(opt1HideExpr({ model: { state: false } })).toBeTrue();
 
             const opt2HideExpr = opt2Field.expressions.hide as any;
-            expect(opt2HideExpr({ state: true })).toBeTrue();
-            expect(opt2HideExpr({ state: false })).toBeFalse();
+            expect(opt2HideExpr({ model: { state: true } })).toBeTrue();
+            expect(opt2HideExpr({ model: { state: false } })).toBeFalse();
           });
         });
       });

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -300,7 +300,7 @@ export class FormlyJsonschema {
                 field.fieldGroup.push({
                   ...this._toFieldConfig({ ...oneOfSchemaItem, properties }, { ...options, resetOnHide: true }),
                   expressions: {
-                    hide: (m: any) => !m || getConstValue(constSchema as JSONSchema7) !== m[property],
+                    hide: (f) => !f.model || getConstValue(constSchema as JSONSchema7) !== f.model[property],
                   },
                 });
               });
@@ -308,7 +308,7 @@ export class FormlyJsonschema {
               field.fieldGroup.push({
                 ...this._toFieldConfig(schemaDeps[property], options),
                 expressions: {
-                  hide: (m: any) => !m || isEmpty(m[property]),
+                  hide: (f) => !f.model || isEmpty(f.model[property]),
                 },
               });
             }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix(json-schema)


**What is the current behavior? (You can also link to an open issue here)**
#3438


**What is the new behavior (if this is a feature change)?**
N/A


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
N/A


**Other information**:
N/A