### PR TITLE
fix(kendo): remove duplicate formControl directive in input type

### DIFF
--- a/src/ui/kendo/input/src/input.type.ts
+++ b/src/ui/kendo/input/src/input.type.ts
@@ -17,7 +17,6 @@ export interface FormlyInputFieldConfig extends FormlyFieldConfig<InputProps> {
       [type]="props.type || 'text'"
       [formlyAttributes]="field"
       [formControl]="formControl"
-      [formControl]="formControl"
     />
     <ng-template #numberTmp>
       <kendo-numerictextbox [formlyAttributes]="field" [formControl]="formControl"> </kendo-numerictextbox>


### PR DESCRIPTION
fix #3435