### PR TITLE
fix(material): use same reference for adding and removing event listener

### DIFF
--- a/src/ui/material/slider/src/slider-input.ts
+++ b/src/ui/material/slider/src/slider-input.ts
@@ -228,10 +228,13 @@ export class MatSliderThumb implements _MatSliderThumb, OnDestroy, ControlValueA
     @Inject(MatSlider) protected _slider: _MatSlider,
   ) {
     this._hostElement = _elementRef.nativeElement;
+    this._onPointerDown = this._onPointerDown.bind(this);
+    this._onPointerMove = this._onPointerMove.bind(this);
+    this._onPointerUp = this._onPointerUp.bind(this);
     this._ngZone.runOutsideAngular(() => {
-      this._hostElement.addEventListener('pointerdown', this._onPointerDown.bind(this));
-      this._hostElement.addEventListener('pointermove', this._onPointerMove.bind(this));
-      this._hostElement.addEventListener('pointerup', this._onPointerUp.bind(this));
+      this._hostElement.addEventListener('pointerdown', this._onPointerDown);
+      this._hostElement.addEventListener('pointermove', this._onPointerMove);
+      this._hostElement.addEventListener('pointerup', this._onPointerUp.bind);
     });
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of ngx-formly, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some unremoved listeners, causing the memory to leak (screenshots below).

[before]
<img width="1277" alt="ngx-formly-before Screen Shot 2023-02-13 at 5 46 05 AM" src="https://user-images.githubusercontent.com/56495631/218342642-d4616e8a-5d3d-4a1c-9e79-02292dce9a5f.png">


Hence we added the fix by adding & removing the listeners with proper references, and you can see the heap size and count of leaks reducing noticeably:
 <br />

<img width="1113" alt="formly-after-add-event Screen Shot 2023-02-13 at 6 02 17 AM" src="https://user-images.githubusercontent.com/56495631/218342692-55a0717e-b1fa-4f7f-86f7-27b31f5407ff.png">


Basically `.bind()` creates a new function reference each time [1-5]; which means the reference passed to the add and remove events were different, and hence the listeners were not actually being removed.

We executed the test suite after the fixes and it successfully passed 56 of 56 total (in watch + non-watch mode)

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering maximum count of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[ngx-formly-scenario.txt](https://github.com/ngx-formly/ngx-formly/files/10717563/ngx-formly-scenario.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.

References:
https://kostasbariotis.com/removeeventlistener-and-this/
https://stackoverflow.com/questions/11565471/removing-event-listener-which-was-added-with-bind
https://stackoverflow.com/questions/28665784/how-to-remove-event-listener-of-a-object-with-bindthis
https://stackoverflow.com/questions/54921027/remove-event-listener-that-has-been-added-using-bindthis
https://stackoverflow.com/questions/46455624/javascript-addeventlistener-removeeventlistener-and-bind
