### PR TITLE
fix(demo): unsubscribe subscriptions to avoid memory leaks

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,17 +1,20 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Location } from '@angular/common';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { filter, map } from 'rxjs/operators';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 import APP_MENU from './app.menu.json';
+
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'formly-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   isSmallDevice$ = this.breakpointObserver.observe([Breakpoints.XSmall]).pipe(map((result) => result.matches));
   menu = APP_MENU;
   usDefaultLayout = !this.location.path().includes('embeddedview=true');
@@ -38,6 +41,11 @@ export class AppComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.documentTitle$.subscribe((title) => this.titleService.setTitle(title));
+    this.documentTitle$.pipe(takeUntil(this.destroy$)).subscribe((title) => this.titleService.setTitle(title));
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }

--- a/demo/src/app/examples/advanced/json-schema/app.component.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.component.ts
@@ -1,15 +1,18 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
 import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
 import { HttpClient } from '@angular/common/http';
-import { tap } from 'rxjs/operators';
+import { tap, takeUntil } from 'rxjs/operators';
+
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'formly-app-example',
   templateUrl: './app.component.html',
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   form: FormGroup;
   model: any;
   options: FormlyFormOptions;
@@ -46,11 +49,17 @@ export class AppComponent {
           this.fields = [this.formlyJsonschema.toFieldConfig(schema)];
           this.model = model;
         }),
+        takeUntil(this.destroy$),
       )
       .subscribe();
   }
 
   submit() {
     alert(JSON.stringify(this.model));
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }

--- a/demo/src/app/examples/other/json-powered/app.component.ts
+++ b/demo/src/app/examples/other/json-powered/app.component.ts
@@ -1,23 +1,30 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
 import { UserService } from './user.service';
+
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'formly-app-example',
   templateUrl: './app.component.html',
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   form = new FormGroup({});
   options: FormlyFormOptions = {};
   model: any;
   fields: FormlyFieldConfig[];
 
   constructor(private userService: UserService) {
-    this.userService.getUserData().subscribe(([model, fields]) => {
-      this.model = model;
-      this.fields = this.mapFields(fields);
-    });
+    this.userService
+      .getUserData()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(([model, fields]) => {
+        this.model = model;
+        this.fields = this.mapFields(fields);
+      });
   }
 
   submit() {
@@ -39,5 +46,10 @@ export class AppComponent {
 
       return f;
     });
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }

--- a/demo/src/app/guides/guides.component.ts
+++ b/demo/src/app/guides/guides.component.ts
@@ -1,5 +1,8 @@
-import { Component, ElementRef, Renderer2, OnInit } from '@angular/core';
+import { Component, ElementRef, Renderer2, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'formly-demo-examples',
@@ -9,7 +12,8 @@ import { ActivatedRoute } from '@angular/router';
     '[style.display]': '"block"',
   },
 })
-export class GuidesComponent implements OnInit {
+export class GuidesComponent implements OnInit, OnDestroy {
+  private destroy$: Subject<any> = new Subject<any>();
   contents: { [id: string]: any } = {
     'getting-started': require('!!raw-loader!!highlight-loader!markdown-loader!docs/getting-started.md'),
     'properties-options': require('!!raw-loader!!highlight-loader!markdown-loader!docs/properties-options.md'),
@@ -25,8 +29,13 @@ export class GuidesComponent implements OnInit {
   constructor(private renderer: Renderer2, private route: ActivatedRoute, private elementRef: ElementRef) {}
 
   ngOnInit() {
-    this.route.params.subscribe(({ id }) => {
+    this.route.params.pipe(takeUntil(this.destroy$)).subscribe(({ id }) => {
       this.renderer.setProperty(this.elementRef.nativeElement, 'innerHTML', this.contents[id].default);
     });
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of ngx-formly, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some unsubscribed subscriptions, causing the memory to leak (screenshots below).

[before]
<img width="1277" alt="ngx-formly-before Screen Shot 2023-02-13 at 5 46 05 AM" src="https://user-images.githubusercontent.com/56495631/218342642-d4616e8a-5d3d-4a1c-9e79-02292dce9a5f.png">

Hence we added the fix by unsubscribing the subscriptions on component destruction, and you can see the heap size and count of leaks reducing noticeably:
 <br />

<img width="1050" alt="after sub Screen Shot 2023-02-13 at 6 14 54 AM" src="https://user-images.githubusercontent.com/56495631/218343605-913be6af-f6f3-408b-90e1-24875457470a.png">

Note. Host listener is used to ensure that ngOnDestroy is called not only when the class destroy, but also when the page refreshes, tab or browser closes or the user navigates away from the page [1]

We executed the test suite after the fixes and it successfully passed 56 of 56 total (in watch + non-watch mode)

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering maximum count of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[ngx-formly-scenario.txt](https://github.com/ngx-formly/ngx-formly/files/10717563/ngx-formly-scenario.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.

References:
[1] https://wesleygrimes.com/angular/2019/03/29/making-upgrades-to-angular-ngondestroy.html