### PR TITLE
feat: pass field to FormlyFieldConfigPresetProvider.getConfiguration

### DIFF
--- a/demo/src/app/app.menu.json
+++ b/demo/src/app/app.menu.json
@@ -114,7 +114,8 @@
           { "path": "/examples/other/button", "label": "Button Type" },
           { "path": "/examples/other/json-powered", "label": "JSON powered" },
           { "path": "/examples/other/input-file", "label": "File input" },
-          { "path": "/examples/other/presets", "label": "Presets" }
+          { "path": "/examples/other/presets", "label": "Presets" },
+          { "path": "/examples/other/presets-fieldgroup", "label": "Fieldgroup Presets" }
         ]
       }
     ]

--- a/demo/src/app/examples/examples.module.ts
+++ b/demo/src/app/examples/examples.module.ts
@@ -238,6 +238,10 @@ import { SharedModule } from '../shared';
                 path: 'presets',
                 loadChildren: () => import('./other/presets/config.module').then((m) => m.ConfigModule),
               },
+              {
+                path: 'presets-fieldgroup',
+                loadChildren: () => import('./other/presets-fieldgroup/config.module').then((m) => m.ConfigModule),
+              },
             ],
           },
         ],

--- a/demo/src/app/examples/other/presets-fieldgroup/app.component.html
+++ b/demo/src/app/examples/other/presets-fieldgroup/app.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/demo/src/app/examples/other/presets-fieldgroup/app.component.ts
+++ b/demo/src/app/examples/other/presets-fieldgroup/app.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'formly-app-example',
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      type: '#group',
+      fieldGroup: [
+        { type: '#firstName' },
+        {
+          type: '#lastName',
+          props: {
+            label: 'Last Name!!!!',
+            required: true,
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/demo/src/app/examples/other/presets-fieldgroup/app.module.ts
+++ b/demo/src/app/examples/other/presets-fieldgroup/app.module.ts
@@ -1,0 +1,53 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule, FORMLY_CONFIG } from '@ngx-formly/core';
+import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
+import { MatTabsModule } from '@angular/material/tabs';
+
+import { AppComponent } from './app.component';
+import { FormlyPresetModule } from 'src/core/preset/src/preset.module';
+import { registerGroupPreset } from './group.preset';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTabsModule,
+    FormlyBootstrapModule,
+    FormlyPresetModule,
+    FormlyModule.forRoot({
+      presets: [
+        {
+          name: 'firstName',
+          config: {
+            key: 'firstName',
+            type: 'input',
+            props: {
+              label: 'First Name',
+            },
+          },
+        },
+        {
+          name: 'lastName',
+          config: {
+            key: 'lastName',
+            type: 'input',
+            props: {
+              label: 'Last Name',
+            },
+          },
+        },
+      ],
+    }),
+  ],
+  declarations: [AppComponent],
+  providers: [
+    {
+      provide: FORMLY_CONFIG,
+      useFactory: registerGroupPreset,
+      multi: true,
+    },
+  ],
+})
+export class AppModule {}

--- a/demo/src/app/examples/other/presets-fieldgroup/config.module.ts
+++ b/demo/src/app/examples/other/presets-fieldgroup/config.module.ts
@@ -1,0 +1,53 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SharedModule, ExamplesRouterViewerComponent } from '../../../shared';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    SharedModule,
+    AppModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ExamplesRouterViewerComponent,
+        data: {
+          examples: [
+            {
+              title: 'Field Group Presets',
+              description: `
+             This example demonstrates how to create a preset for fields with a <code>fieldGroup</code>. 
+             You can use the <code>field</code> argument passed to <code>getConfiguration</code> in a <code>FormlyFieldConfigPresetProvider</code> to merge the preset with the provided <code>fieldGroup</code>.
+            `,
+              component: AppComponent,
+              files: [
+                {
+                  file: 'app.component.html',
+                  content: require('!!highlight-loader?raw=true&lang=html!./app.component.html'),
+                  filecontent: require('!!raw-loader!./app.component.html'),
+                },
+                {
+                  file: 'app.component.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.component.ts'),
+                  filecontent: require('!!raw-loader!./app.component.ts'),
+                },
+                {
+                  file: 'salutation.preset.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./group.preset.ts'),
+                  filecontent: require('!!raw-loader!./group.preset.ts'),
+                },
+                {
+                  file: 'app.module.ts',
+                  content: require('!!highlight-loader?raw=true&lang=typescript!./app.module.ts'),
+                  filecontent: require('!!raw-loader!./app.module.ts'),
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]),
+  ],
+})
+export class ConfigModule {}

--- a/demo/src/app/examples/other/presets-fieldgroup/group.preset.ts
+++ b/demo/src/app/examples/other/presets-fieldgroup/group.preset.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { ConfigOption, FormlyFieldConfig, FormlyFieldConfigPresetProvider } from '@ngx-formly/core';
+
+@Injectable()
+export class GroupPresetProvider implements FormlyFieldConfigPresetProvider {
+  constructor() {}
+  getConfiguration(field?: FormlyFieldConfig): FormlyFieldConfig {
+    return {
+      key: 'group',
+      type: 'formly-group',
+      props: { label: 'Group' },
+      fieldGroup: [
+        {
+          key: 'prefix',
+          type: 'input',
+          props: { label: 'Prefixed Field' },
+        },
+        ...(field?.fieldGroup ?? []),
+      ],
+    };
+  }
+}
+
+export function registerGroupPreset(): ConfigOption {
+  return {
+    presets: [
+      {
+        name: 'group',
+        config: new GroupPresetProvider(),
+      },
+    ],
+  };
+}

--- a/src/core/preset/src/preset-substitution.extension.ts
+++ b/src/core/preset/src/preset-substitution.extension.ts
@@ -1,4 +1,4 @@
-import { FormlyConfig, FormlyExtension, FormlyFieldConfig, ɵreverseDeepMerge } from '@ngx-formly/core';
+import { FormlyConfig, FormlyExtension, FormlyFieldConfig, ɵreverseDeepMergeWithArrays } from '@ngx-formly/core';
 export class PresetSubstitutionExtension implements FormlyExtension {
   constructor(private formlyConfig: FormlyConfig) {}
 
@@ -11,9 +11,9 @@ export class PresetSubstitutionExtension implements FormlyExtension {
 
     const { type: _, ...fieldConfigWithoutType } = field;
     if (preset) {
-      const merged = ɵreverseDeepMerge(
+      const merged = ɵreverseDeepMergeWithArrays(
         fieldConfigWithoutType,
-        'getConfiguration' in preset ? preset.getConfiguration() : preset,
+        'getConfiguration' in preset ? preset.getConfiguration(field) : preset,
       );
       Object.assign(field, merged);
     }

--- a/src/core/src/lib/core.ts
+++ b/src/core/src/lib/core.ts
@@ -6,6 +6,7 @@ export {
   FormlyFieldProps,
   ConfigOption,
   FormlyExtension,
+  FormlyFieldConfigPresetProvider,
 } from './models';
 export { FormlyField } from './components/formly.field';
 export { FormlyAttributes as ɵFormlyAttributes } from './templates/formly.attributes';
@@ -20,6 +21,7 @@ export { FieldWrapper } from './templates/field.wrapper';
 export { FormlyModule } from './core.module';
 export { defineHiddenProp as ɵdefineHiddenProp } from './utils';
 export { reverseDeepMerge as ɵreverseDeepMerge } from './utils';
+export { reverseDeepMergeWithArrays as ɵreverseDeepMergeWithArrays } from './utils';
 export { getFieldValue as ɵgetFieldValue } from './utils';
 export { clone as ɵclone } from './utils';
 export { observe as ɵobserve } from './utils';

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -56,7 +56,7 @@ export interface PresetOption {
 }
 
 export interface FormlyFieldConfigPresetProvider {
-  getConfiguration: () => FormlyFieldConfig;
+  getConfiguration: (field?: FormlyFieldConfig) => FormlyFieldConfig;
 }
 
 export interface ConfigOption {

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -103,6 +103,21 @@ export function getFieldValue(field: FormlyFieldConfig): any {
   return model;
 }
 
+export function reverseDeepMergeWithArrays(dest: any, ...args: any[]) {
+  args.forEach((src) => {
+    for (const srcArg in src) {
+      if (isNil(dest[srcArg]) || isBlankString(dest[srcArg])) {
+        dest[srcArg] = clone(src[srcArg]);
+      } else if (objAndSameType(dest[srcArg], src[srcArg])) {
+        reverseDeepMerge(dest[srcArg], src[srcArg]);
+      } else if (Array.isArray(dest[srcArg]) || Array.isArray(src[srcArg])) {
+        dest[srcArg] = clone(src[srcArg]);
+      }
+    }
+  });
+  return dest;
+}
+
 export function reverseDeepMerge(dest: any, ...args: any[]) {
   args.forEach((src) => {
     for (const srcArg in src) {


### PR DESCRIPTION
refer to https://github.com/ngx-formly/ngx-formly/issues/3456 for details

@aitboudad the problem is that `reverseDeepMerge` completely ignores arrays, which sucks for the `fieldGroup` merging use case. So I copied and modified it to also handle arrays.