### PR TITLE
fix: merge schema properties with definitions $ref

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -853,6 +853,40 @@ describe('Service: FormlyJsonschema', () => {
         });
       });
 
+      it('should keep schema properties with definition', () => {
+        const schema: JSONSchema7 = {
+          definitions: {
+            address: {
+              properties: {
+                address1: { type: 'string', title: 'Address 1' },
+              },
+            },
+          },
+          type: 'object',
+          properties: {
+            billing_address: {
+              properties: {
+                customAddress: { type: 'string', title: 'Custom address' },
+              },
+              $ref: '#/definitions/address',
+            },
+          },
+        };
+
+        const config = formlyJsonschema.toFieldConfig(schema);
+
+        expect(config.fieldGroup[0]).toEqual({
+          key: 'billing_address',
+          type: 'object',
+          defaultValue: undefined,
+          fieldGroup: expect.any(Array),
+          props: emmptyFieldProps,
+          templateOptions: emmptyFieldProps,
+          validators: expectTypeValidator(['object']),
+        });
+        expect(config.fieldGroup[0].fieldGroup.map((f) => f.key)).toEqual(['customAddress', 'address1']);
+      });
+
       it('should use the locally defined annotations', () => {
         const schema: JSONSchema7 = {
           definitions: {

--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -423,13 +423,6 @@ export class FormlyJsonschema {
       ];
     }
 
-    if (schema.oneOf && !field.type) {
-      delete field.key;
-      field.fieldGroup = [
-        this.resolveMultiSchema('oneOf', <JSONSchema7[]>schema.oneOf, { ...options, key, shareFormControl: false }),
-      ];
-    }
-
     // map in possible formlyConfig options from the widget property
     if (schema.widget?.formlyConfig) {
       field = this.mergeFields(field, schema.widget.formlyConfig);
@@ -576,6 +569,7 @@ export class FormlyJsonschema {
 
     return {
       ...definition,
+      ...(schema.properties ? { properties: { ...schema.properties, ...definition.properties } } : {}),
       ...['title', 'description', 'default', 'widget'].reduce((annotation, p) => {
         if (schema.hasOwnProperty(p)) {
           annotation[p] = (schema as any)[p];


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

- Remove some duplicated code
- Corrects properties with the use of a definition

to have the same behavior as here  https://rjsf-team.github.io/react-jsonschema-form/

Try with :
```
{
          definitions: {
            address: {
              properties: {
                address1: { type: 'string', title: 'Address 1' },
              },
            },
          },
          type: 'object',
          properties: {
            billing_address: {
              properties: {
                customAddress: { type: 'string', title: 'Custom address' },
              },
              $ref: '#/definitions/address',
            },
          },
        }
```


**What is the current behavior? (You can also link to an open issue here)**

Only add definitions properties

**What is the new behaviour  (if this is a feature change)?**

Merge add definitions properties and parent one


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
