### PR TITLE
feat(core): export interfaces

### DIFF
--- a/src/core/src/lib/core.ts
+++ b/src/core/src/lib/core.ts
@@ -1,16 +1,18 @@
 export { FormlyForm } from './components/formly.form';
 export {
   FormlyFieldConfig,
+  FormlyFieldConfigCache,
   FormlyTemplateOptions,
   FormlyFormOptions,
   FormlyFieldProps,
   ConfigOption,
   FormlyExtension,
+  TypeOption,
 } from './models';
 export { FormlyField } from './components/formly.field';
 export { FormlyAttributes as ɵFormlyAttributes } from './templates/formly.attributes';
 export { FormlyGroup as ɵFormlyGroup } from './templates/formly.group';
-export { FormlyTemplate as ɵFormlyTemplate } from './components/formly.template';
+export { FormlyTemplate as ɵFormlyTemplate, FormlyFieldTemplates } from './components/formly.template';
 export { FormlyValidationMessage as ɵFormlyValidationMessage } from './templates/formly.validation-message';
 export { FORMLY_CONFIG, FormlyConfig } from './services/formly.config';
 export { FormlyFormBuilder } from './services/formly.builder';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Export core interfaces so they can be extended with more features.


**What is the current behavior? (You can also link to an open issue here)**
https://github.com/ngx-formly/ngx-formly/issues/3606


**What is the new behavior (if this is a feature change)?**
`FormlyFieldConfigCache`, `FormlyFieldTemplates` and `TypeOption` interfaces are now exported.



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
