### PR TITLE
fix(kendo): update peer dependencies

### DIFF
--- a/src/ui/kendo/package.json
+++ b/src/ui/kendo/package.json
@@ -7,8 +7,8 @@
   },
   "peerDependencies": {
     "@ngx-formly/core": "0.0.0-FORMLY-VERSION",
-    "@progress/kendo-angular-label": ">=^4.0.0",
-    "@progress/kendo-angular-dropdowns": ">=^7.0.2",
-    "@progress/kendo-angular-inputs": ">=^9.0.3"
+    "@progress/kendo-angular-label": ">=4.0.0",
+    "@progress/kendo-angular-dropdowns": ">=7.0.2",
+    "@progress/kendo-angular-inputs": ">=9.0.3"
   }
 }


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
this makes any available version of kendo ui compatible for the library

What is the current behavior? (You can also link to an open issue here)
https://github.com/ngx-formly/ngx-formly/issues/3571

What is the new behavior (if this is a feature change)?
any version of kendo above the minimum will be accepted

Please check if the PR fulfills these requirements

 The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
 A unit test has been written for this change.
 Running npm run build produced a successful build. (Unit testing can be done by running npm test;)
 My code has been linted. (npm run lint to do this. npm run build will fail if there are files not linted.)
Please provide a screenshot of this feature before and after your code changes, if applicable.