### PR TITLE
fix(core): Select Options Pipe has wrong return types

### DIFF
--- a/src/core/select/src/select-options.pipe.ts
+++ b/src/core/select/src/select-options.pipe.ts
@@ -12,9 +12,9 @@ export interface FormlySelectOption {
 
 export interface FormlyFieldSelectProps extends FormlyFieldProps {
   groupProp?: string | ((option: any) => string);
-  labelProp?: string | ((option: any) => any);
-  valueProp?: string | ((option: any) => boolean);
-  disabledProp?: string | ((option: any) => string);
+  labelProp?: string | ((option: any) => string);
+  valueProp?: string | ((option: any) => any);
+  disabledProp?: string | ((option: any) => boolean);
 }
 
 type ITransformOption = {


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Looks like that the functions return types on elect Options Pipe have the wrong types

labelProp was (any)=> any , it's changed to string
valueProp was (any)=>boolean, it's changed to any
disabledProp was (any)=> string, it's changed to boolean

What is the current behavior? (You can also link to an open issue here)

What is the new behavior (if this is a feature change)?

Please check if the PR fulfills these requirements

[X ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
 A unit test has been written for this change.
[X ] Running npm run build produced a successful build. (Unit testing can be done by running npm test;)
[X ] My code has been linted. (npm run lint to do this. npm run build will fail if there are files not linted.)
Please provide a screenshot of this feature before and after your code changes, if applicable.

Other information:
