### PR TITLE
feat(kendo): add primitive option in props

### DIFF
--- a/src/ui/kendo/select/src/select.type.ts
+++ b/src/ui/kendo/select/src/select.type.ts
@@ -20,7 +20,7 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
       [data]="props.options | formlySelectOptions : field | async"
       [textField]="'label'"
       [valueField]="'value'"
-      [valuePrimitive]="props.primitive??true"
+      [valuePrimitive]="props.primitive ?? true"
       (valueChange)="props.change && props.change(field, $event)"
     >
     </kendo-dropdownlist>

--- a/src/ui/kendo/select/src/select.type.ts
+++ b/src/ui/kendo/select/src/select.type.ts
@@ -3,7 +3,9 @@ import { FieldTypeConfig, FormlyFieldConfig } from '@ngx-formly/core';
 import { FieldType, FormlyFieldProps } from '@ngx-formly/kendo/form-field';
 import { FormlyFieldSelectProps } from '@ngx-formly/core/select';
 
-interface SelectProps extends FormlyFieldProps, FormlyFieldSelectProps {}
+interface SelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
+  primitive?: boolean;
+}
 
 export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> {
   type: 'select' | Type<FormlyFieldSelect>;
@@ -18,7 +20,7 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
       [data]="props.options | formlySelectOptions : field | async"
       [textField]="'label'"
       [valueField]="'value'"
-      [valuePrimitive]="true"
+      [valuePrimitive]="props.primitive??true"
       (valueChange)="props.change && props.change(field, $event)"
     >
     </kendo-dropdownlist>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
kendo template has fixed value in primitive, if you need to pass an object on the value it makes an error 


**What is the current behavior? (You can also link to an open issue here)**
#3529 


**What is the new behavior (if this is a feature change)?**
there will be a primitive prop value on kendo select props


**Please check if the PR fulfills these requirements**
- [X ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [X ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
