### PR TITLE
feat(core):enable map function on itransformoption

### DIFF
--- a/src/core/select/src/select-options.pipe.ts
+++ b/src/core/select/src/select-options.pipe.ts
@@ -15,6 +15,7 @@ export interface FormlyFieldSelectProps extends FormlyFieldProps {
   labelProp?: string | ((option: any) => string);
   valueProp?: string | ((option: any) => any);
   disabledProp?: string | ((option: any) => boolean);
+  mapProp?: ((option: any) => FormlySelectOption | any);
 }
 
 type ITransformOption = {
@@ -22,6 +23,7 @@ type ITransformOption = {
   valueProp: (option: any) => any;
   disabledProp: (option: any) => boolean;
   groupProp: (option: any) => string;
+  mapProp?: ((option: any) => FormlySelectOption | any)
 };
 
 @Pipe({ name: 'formlySelectOptions' })
@@ -29,7 +31,7 @@ export class FormlySelectOptionsPipe implements PipeTransform, OnDestroy {
   private _subscription: Subscription;
   private _options: BehaviorSubject<any[]>;
 
-  transform(options: any, field?: FormlyFieldConfig): Observable<FormlySelectOption[]> {
+  transform(options: any, field?: FormlyFieldConfig): Observable<FormlySelectOption[] | any[]> {
     if (!(options instanceof Observable)) {
       options = this.observableOf(options, field);
     } else {
@@ -43,23 +45,29 @@ export class FormlySelectOptionsPipe implements PipeTransform, OnDestroy {
     this.dispose();
   }
 
-  private transformOptions(options: any[], field?: FormlyFieldConfig): FormlySelectOption[] {
+  private transformOptions(options: any[], field?: FormlyFieldConfig): FormlySelectOption[] | any[] {
     const to = this.transformSelectProps(field);
 
-    const opts: FormlySelectOption[] = [];
+    const opts: FormlySelectOption[] | any[] = [];
     const groups: { [id: string]: number } = {};
 
     options?.forEach((option) => {
-      const o = this.transformOption(option, to);
-      if (o.group) {
-        const id = groups[o.label];
-        if (id === undefined) {
-          groups[o.label] = opts.push(o) - 1;
+      if (to.mapProp) {
+        const mapped = to.mapProp(option);
+        opts.push(mapped);
+      }
+      else {
+        const o = this.transformOption(option, to);
+        if (o.group) {
+          const id = groups[o.label];
+          if (id === undefined) {
+            groups[o.label] = opts.push(o) - 1;
+          } else {
+            o.group.forEach((o) => opts[id].group.push(o));
+          }
         } else {
-          o.group.forEach((o) => opts[id].group.push(o));
+          opts.push(o);
         }
-      } else {
-        opts.push(o);
       }
     });
 
@@ -97,6 +105,7 @@ export class FormlySelectOptionsPipe implements PipeTransform, OnDestroy {
       labelProp: selectPropFn(props.labelProp || 'label'),
       valueProp: selectPropFn(props.valueProp || 'value'),
       disabledProp: selectPropFn(props.disabledProp || 'disabled'),
+      mapProp: props.mapProp,
     };
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This is an Idea to create a function to map the result on the FormlySelectOptionsPipe 

**What is the current behavior? (You can also link to an open issue here)**

This is the implementation of the #3624 

**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
