### PR TITLE
feat(material): add panelClass to mat-select props

### DIFF
--- a/src/ui/material/select/src/select.type.spec.ts
+++ b/src/ui/material/select/src/select.type.spec.ts
@@ -124,7 +124,7 @@ describe('ui-material: Formly Field Select Component', () => {
       expect(queryAll('mat-option')).toHaveLength(3);
     });
 
-    it('mat-options should have specified custom class', () => {
+    it('panelClass should be used to add class to select overlay div', () => {
       const panelClass = 'my-custom-panel-class';
 
       const { query, queryAll, detectChanges } = renderComponent({

--- a/src/ui/material/select/src/select.type.spec.ts
+++ b/src/ui/material/select/src/select.type.spec.ts
@@ -123,6 +123,35 @@ describe('ui-material: Formly Field Select Component', () => {
 
       expect(queryAll('mat-option')).toHaveLength(3);
     });
+
+    it('mat-options should have specified custom class', () => {
+      const optionsClass = 'my-custom-class';
+
+      const { query, queryAll, detectChanges } = renderComponent({
+        key: 'sportId',
+        type: 'select',
+        props: {
+          optionsClass,
+          options: [
+            { id: '1', name: 'Soccer' },
+            { id: '2', name: 'Basketball' },
+            { id: { test: 'A' }, name: 'Not Soccer or Basketball' },
+          ],
+          valueProp: 'id',
+          labelProp: 'name',
+        },
+      });
+
+      query('.mat-select-trigger').triggerEventHandler('click', {});
+      detectChanges();
+
+      const matOptions = queryAll('mat-option');
+
+      matOptions.forEach((option) => {
+        const nativeElement = option.nativeElement;
+        expect(nativeElement.className).toInclude(optionsClass);
+      });
+    });
   });
 
   describe('multi select', () => {

--- a/src/ui/material/select/src/select.type.spec.ts
+++ b/src/ui/material/select/src/select.type.spec.ts
@@ -125,13 +125,13 @@ describe('ui-material: Formly Field Select Component', () => {
     });
 
     it('mat-options should have specified custom class', () => {
-      const optionsClass = 'my-custom-class';
+      const panelClass = 'my-custom-panel-class';
 
       const { query, queryAll, detectChanges } = renderComponent({
         key: 'sportId',
         type: 'select',
         props: {
-          optionsClass,
+          panelClass,
           options: [
             { id: '1', name: 'Soccer' },
             { id: '2', name: 'Basketball' },
@@ -145,12 +145,8 @@ describe('ui-material: Formly Field Select Component', () => {
       query('.mat-select-trigger').triggerEventHandler('click', {});
       detectChanges();
 
-      const matOptions = queryAll('mat-option');
-
-      matOptions.forEach((option) => {
-        const nativeElement = option.nativeElement;
-        expect(nativeElement.className).toInclude(optionsClass);
-      });
+      const panel = queryAll('div').find((x) => !!x.classes[panelClass]);
+      expect(panel).not.toBeNull();
     });
   });
 

--- a/src/ui/material/select/src/select.type.ts
+++ b/src/ui/material/select/src/select.type.ts
@@ -11,7 +11,7 @@ interface SelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
   disableOptionCentering?: boolean;
   typeaheadDebounceInterval?: number;
   compareWith?: (o1: any, o2: any) => boolean;
-  optionsClass?: string;
+  panelClass?: string;
 }
 
 export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> {
@@ -44,6 +44,7 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
       [aria-labelledby]="_getAriaLabelledby()"
       [disableOptionCentering]="props.disableOptionCentering"
       [typeaheadDebounceInterval]="props.typeaheadDebounceInterval"
+      [panelClass]="props.panelClass"
     >
       <ng-container *ngIf="props.options | formlySelectOptions : field | async as selectOptions">
         <ng-container
@@ -54,22 +55,11 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
         </ng-container>
         <ng-container *ngFor="let item of selectOptions">
           <mat-optgroup *ngIf="item.group" [label]="item.label">
-            <mat-option
-              *ngFor="let child of item.group"
-              [value]="child.value"
-              [disabled]="child.disabled"
-              [class]="props.optionsClass"
-            >
+            <mat-option *ngFor="let child of item.group" [value]="child.value" [disabled]="child.disabled">
               {{ child.label }}
             </mat-option>
           </mat-optgroup>
-          <mat-option
-            *ngIf="!item.group"
-            [value]="item.value"
-            [disabled]="item.disabled"
-            [class]="props.optionsClass"
-            >{{ item.label }}</mat-option
-          >
+          <mat-option *ngIf="!item.group" [value]="item.value" [disabled]="item.disabled">{{ item.label }}</mat-option>
         </ng-container>
       </ng-container>
     </mat-select>

--- a/src/ui/material/select/src/select.type.ts
+++ b/src/ui/material/select/src/select.type.ts
@@ -11,6 +11,7 @@ interface SelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
   disableOptionCentering?: boolean;
   typeaheadDebounceInterval?: number;
   compareWith?: (o1: any, o2: any) => boolean;
+  optionsClass?: string;
 }
 
 export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> {
@@ -53,11 +54,22 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
         </ng-container>
         <ng-container *ngFor="let item of selectOptions">
           <mat-optgroup *ngIf="item.group" [label]="item.label">
-            <mat-option *ngFor="let child of item.group" [value]="child.value" [disabled]="child.disabled">
+            <mat-option
+              *ngFor="let child of item.group"
+              [value]="child.value"
+              [disabled]="child.disabled"
+              [class]="props.optionsClass"
+            >
               {{ child.label }}
             </mat-option>
           </mat-optgroup>
-          <mat-option *ngIf="!item.group" [value]="item.value" [disabled]="item.disabled">{{ item.label }}</mat-option>
+          <mat-option
+            *ngIf="!item.group"
+            [value]="item.value"
+            [disabled]="item.disabled"
+            [class]="props.optionsClass"
+            >{{ item.label }}</mat-option
+          >
         </ng-container>
       </ng-container>
     </mat-select>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
Cannot style the mat-options when using a formly select. Is there another way to do this with the current behaviour? 


**What is the new behavior (if this is a feature change)?**
Allows you to specify a class name to the mat-options. This enables the user to help theme the mat-select control. 


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
