### PR TITLE
fix(core): handle undefined source observer

### DIFF
--- a/src/core/src/lib/components/formly.field.ts
+++ b/src/core/src/lib/components/formly.field.ts
@@ -268,7 +268,7 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
 
     const subscribes = [
       observeDeep(field, ['props'], () => field.options.detectChanges(field)),
-      observeDeep(field.options, ['formState'], () => field.options.detectChanges(field)),
+      observeDeep(field, ['options', 'formState'], () => field.options.detectChanges(field)),
     ];
 
     for (const key of Object.keys(field._expressions || {})) {

--- a/src/core/src/lib/utils.spec.ts
+++ b/src/core/src/lib/utils.spec.ts
@@ -317,6 +317,18 @@ describe('observeDeep', () => {
 
     expect(spy).toHaveBeenCalledTimes(0);
   });
+
+  it('should not throw when unsubscribing from falsy source', () => {
+    const spy = jest.fn();
+
+    const unsubUndefined = observeDeep(undefined, ['address'], spy);
+    expect(() => unsubUndefined()).not.toThrow();
+
+    const unsubNull = observeDeep(null, ['address'], spy);
+    expect(() => unsubNull()).not.toThrow();
+
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe('observe', () => {

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -225,7 +225,7 @@ interface IObserveTarget<T> {
   };
 }
 
-export function observeDeep(source: any, paths: string[], setFn: () => void): () => void {
+export function observeDeep<T = any>(source: IObserveTarget<T>, paths: string[], setFn: () => void): () => void {
   let observers: Function[] = [];
 
   const unsubscribe = () => {
@@ -250,6 +250,10 @@ export function observeDeep(source: any, paths: string[], setFn: () => void): ()
 }
 
 export function observe<T = any>(o: IObserveTarget<T>, paths: string[], setFn: IObserveFn<T>): IObserver<T> {
+  if (!isObject(o)) {
+    o = {};
+  }
+
   if (!o._observers) {
     defineHiddenProp(o, '_observers', {});
   }


### PR DESCRIPTION
Bug fix

After upgrading to v6 there were certain scenarios (mainly in tests of our system) where reassigning the full config many times in succession would result in the `source` of the utility function `observeDeep` to be called with `undefined`
This would result in an invalid unsubscribe function to be returned.

`source` is defined as `any` but the current code does not cater for handling the "falsy" scenario

**What is the new behavior (if this is a feature change)?**
When `source` is `undefined` or `null` an empty `unsubscribe` function is returned allowing callers to not crash.
