### PR TITLE
feat(bootstrap): added aria tags for input validation (#3737)

### DIFF
--- a/src/ui/bootstrap/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.spec.ts
@@ -43,6 +43,17 @@ describe('ui-bootstrap: Checkbox Type', () => {
     });
   });
 
+  it('should set aria-invalid to true on invalid', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'checkbox',
+      validation: { show: true },
+      props: { required: true },
+    });
+
+    expect(query('input[type="checkbox"]').nativeElement.getAttribute('aria-invalid')).toBe('true');
+  });
+
   it('should bind control value on change', () => {
     const changeSpy = jest.fn();
     const { query, field, detectChanges } = renderComponent({

--- a/src/ui/bootstrap/checkbox/src/checkbox.type.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.ts
@@ -30,6 +30,8 @@ export interface FormlyCheckboxFieldConfig extends FormlyFieldConfig<CheckboxPro
           [indeterminate]="props.indeterminate && formControl.value == null"
           [formControl]="formControl"
           [formlyAttributes]="field"
+          [attr.aria-describedby]="id + '-formly-validation-error'"
+          [attr.aria-invalid]="showError"
         />
         <label *ngIf="props.formCheck !== 'nolabel'" [for]="id" class="form-check-label">
           {{ props.label }}

--- a/src/ui/bootstrap/form-field/src/form-field.wrapper.ts
+++ b/src/ui/bootstrap/form-field/src/form-field.wrapper.ts
@@ -29,7 +29,7 @@ export interface FormlyFieldProps extends CoreFormlyFieldProps {
       </ng-container>
 
       <div *ngIf="showError" class="invalid-feedback" [style.display]="'block'">
-        <formly-validation-message [field]="field"></formly-validation-message>
+        <formly-validation-message id="{{ id }}-formly-validation-error" [field]="field"></formly-validation-message>
       </div>
 
       <small *ngIf="props.description" class="form-text text-muted">{{ props.description }}</small>

--- a/src/ui/bootstrap/input/src/input.type.spec.ts
+++ b/src/ui/bootstrap/input/src/input.type.spec.ts
@@ -96,6 +96,17 @@ describe('ui-bootstrap: Input Type', () => {
     expect(classes['is-invalid']).toBeTrue();
   });
 
+  it('should set aria-invalid to true on invalid', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'input',
+      validation: { show: true },
+      props: { required: true },
+    });
+
+    expect(query('input[type="text"]').nativeElement.getAttribute('aria-invalid')).toBe('true');
+  });
+
   it('should bind control value on change', () => {
     const changeSpy = jest.fn();
     const { query, field, detectChanges } = renderComponent({

--- a/src/ui/bootstrap/input/src/input.type.ts
+++ b/src/ui/bootstrap/input/src/input.type.ts
@@ -19,6 +19,8 @@ export interface FormlyInputFieldConfig extends FormlyFieldConfig<InputProps> {
         class="form-control"
         [formlyAttributes]="field"
         [class.is-invalid]="showError"
+        [attr.aria-describedby]="id + '-formly-validation-error'"
+        [attr.aria-invalid]="showError"
       />
       <ng-template #numberTmp>
         <input
@@ -27,6 +29,8 @@ export interface FormlyInputFieldConfig extends FormlyFieldConfig<InputProps> {
           class="form-control"
           [formlyAttributes]="field"
           [class.is-invalid]="showError"
+          [attr.aria-describedby]="id + '-formly-validation-error'"
+          [attr.aria-invalid]="showError"
         />
       </ng-template>
     </ng-template>

--- a/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.ts
+++ b/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.ts
@@ -21,6 +21,8 @@ export interface FormlyMultiCheckboxFieldConfig extends FormlyFieldConfig<MultiC
           'form-check-inline': props.formCheck === 'inline' || props.formCheck === 'inline-switch',
           'form-switch': props.formCheck === 'switch' || props.formCheck === 'inline-switch'
         }"
+        [attr.aria-describedby]="id + '-formly-validation-error'"
+        [attr.aria-invalid]="showError"
       >
         <input
           type="checkbox"

--- a/src/ui/bootstrap/radio/src/radio.type.spec.ts
+++ b/src/ui/bootstrap/radio/src/radio.type.spec.ts
@@ -40,6 +40,20 @@ describe('ui-bootstrap: Radio Type', () => {
     expect(query('input[type="radio"]').classes['is-invalid']).toBeTrue();
   });
 
+  it('should set aria-invalid to true on invalid', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'radio',
+      validation: { show: true },
+      props: {
+        options: [{ value: 1, label: 'label 1' }],
+        required: true,
+      },
+    });
+
+    expect(query('input[type="radio"]').nativeElement.getAttribute('aria-invalid')).toBe('true');
+  });
+
   it('should render with custom formCheck', () => {
     const { query, field, detectChanges } = renderComponent({
       key: 'name',

--- a/src/ui/bootstrap/radio/src/radio.type.ts
+++ b/src/ui/bootstrap/radio/src/radio.type.ts
@@ -30,6 +30,8 @@ export interface FormlyRadioFieldConfig extends FormlyFieldConfig<RadioProps> {
           [value]="option.value"
           [formControl]="option.disabled ? disabledControl : formControl"
           [formlyAttributes]="field"
+          [attr.aria-describedby]="id + '-formly-validation-error'"
+          [attr.aria-invalid]="showError"
         />
         <label class="form-check-label" [for]="id + '_' + i">
           {{ option.label }}

--- a/src/ui/bootstrap/select/src/select.type.spec.ts
+++ b/src/ui/bootstrap/select/src/select.type.spec.ts
@@ -138,5 +138,27 @@ describe('ui-bootstrap: Select Type', () => {
 
       expect(queryAll('select option')).toHaveLength(3);
     });
+
+    it('should set aria-invalid on select to true on invalid', () => {
+      const { query } = renderComponent({
+        key: 'name',
+        type: 'select',
+        validation: { show: true },
+        props: { required: true },
+      });
+
+      expect(query('select').nativeElement.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('should set aria-invalid on enum to true on invalid', () => {
+      const { query } = renderComponent({
+        key: 'name',
+        type: 'enum',
+        validation: { show: true },
+        props: { required: true },
+      });
+
+      expect(query('select').nativeElement.getAttribute('aria-invalid')).toBe('true');
+    });
   });
 });

--- a/src/ui/bootstrap/select/src/select.type.ts
+++ b/src/ui/bootstrap/select/src/select.type.ts
@@ -26,6 +26,8 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
         [compareWith]="props.compareWith"
         [class.is-invalid]="showError"
         [formlyAttributes]="field"
+        [attr.aria-describedby]="id + '-formly-validation-error'"
+        [attr.aria-invalid]="showError"
       >
         <ng-container *ngIf="props.options | formlySelectOptions : field | async as opts">
           <ng-container *ngFor="let opt of opts">
@@ -50,6 +52,8 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
           [compareWith]="props.compareWith"
           [class.is-invalid]="showError"
           [formlyAttributes]="field"
+          [attr.aria-describedby]="id + '-formly-validation-error'"
+          [attr.aria-invalid]="showError"
         >
           <option *ngIf="props.placeholder" [ngValue]="undefined">{{ props.placeholder }}</option>
           <ng-container *ngIf="props.options | formlySelectOptions : field | async as opts">

--- a/src/ui/bootstrap/textarea/src/textarea.type.spec.ts
+++ b/src/ui/bootstrap/textarea/src/textarea.type.spec.ts
@@ -42,6 +42,17 @@ describe('ui-bootstrap: Textarea Type', () => {
     expect(query('textarea').classes['is-invalid']).toBeTrue();
   });
 
+  it('should set aria-invalid to true on invalid', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'textarea',
+      validation: { show: true },
+      props: { required: true },
+    });
+
+    expect(query('textarea').nativeElement.getAttribute('aria-invalid')).toBe('true');
+  });
+
   it('should bind control value on change', () => {
     const changeSpy = jest.fn();
     const { query, field, detectChanges } = renderComponent({

--- a/src/ui/bootstrap/textarea/src/textarea.type.ts
+++ b/src/ui/bootstrap/textarea/src/textarea.type.ts
@@ -22,6 +22,8 @@ export interface FormlyTextAreaFieldConfig extends FormlyFieldConfig<TextAreaPro
         class="form-control"
         [class.is-invalid]="showError"
         [formlyAttributes]="field"
+        [attr.aria-describedby]="id + '-formly-validation-error'"
+        [attr.aria-invalid]="showError"
       >
       </textarea>
     </ng-template>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This is a feature change to allow for screen reader to mention that an input is invalid and to read the validation error message that is paired with the form control.


**What is the current behavior? (You can also link to an open issue here)**
The current behavior is to not use aria-invalid or aria-descibedby. [Here is the issue I created for this problem](https://github.com/ngx-formly/ngx-formly/issues/3737)

**What is the new behavior (if this is a feature change)?**
The new change will only affect screen readers in bootstrap. It will now read that an input is invalid once shown error is called, and it will also read the error message that is paired with the form control.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
