### PR TITLE
fix(core): add searching in fieldArray property using getField function

### DIFF
--- a/src/core/src/lib/utils.spec.ts
+++ b/src/core/src/lib/utils.spec.ts
@@ -494,6 +494,13 @@ describe('getField', () => {
     expect(childField.key).toEqual('child1');
   });
 
+  it('should find the child in field array', () => {
+    const field = { fieldArray: { fieldGroup: [{ key: 'child1' }] } };
+    const childField = getField(field, 'child1');
+
+    expect(childField.key).toEqual('child1');
+  });
+
   it('should return undefined when field does not exist', () => {
     expect(getField({}, ['parent', 'child1'])).toBeUndefined();
   });

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -319,6 +319,10 @@ export function observe<T = any>(o: IObserveTarget<T>, paths: string[], setFn: I
 export function getField(f: FormlyFieldConfig, key: FormlyFieldConfig['key']): FormlyFieldConfig {
   key = (Array.isArray(key) ? key.join('.') : key) as string;
   if (!f.fieldGroup) {
+    if (f.fieldArray && typeof f.fieldArray === 'object') {
+      return getField(f.fieldArray, key);
+    }
+
     return undefined;
   }
 


### PR DESCRIPTION
add searching for field by path including fieldArray property using getField function from utils

fix #3759

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bug fix

**What is the new behavior (if this is a feature change)?**

the fields inside `fieldArray` object are being searched while using `getField` utility function

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
