### PR TITLE
perf(core): set the asyncValidators when async validators are present

### DIFF
--- a/src/core/src/lib/extensions/field-form/field-form.spec.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.spec.ts
@@ -158,11 +158,27 @@ describe('FieldFormExtension', () => {
       formControl,
       props: { required: true },
       form: new FormGroup({ test: formControl }),
+      asyncValidators: {
+        custom: () => new Promise(null),
+      },
     });
 
     expect(formControl.setValidators).toHaveBeenCalledTimes(1);
     expect(formControl.setAsyncValidators).toHaveBeenCalledTimes(1);
     expect(formControl.updateValueAndValidity).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call "setAsyncValidators" when no asyncValidator is present in field', () => {
+    const formControl = new FormControl();
+    jest.spyOn(formControl, 'setAsyncValidators');
+    buildField({
+      key: 'test',
+      formControl,
+      props: { required: true },
+      form: new FormGroup({ test: formControl }),
+    });
+
+    expect(formControl.setAsyncValidators).not.toHaveBeenCalled();
   });
 
   it('should updateValueAndValidity of detached field', () => {

--- a/src/core/src/lib/extensions/field-form/field-form.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.ts
@@ -97,19 +97,26 @@ export class FieldFormExtension implements FormlyExtension {
           }
         }
 
-        if (null === c.validator || null === c.asyncValidator) {
+        if (null === c.validator) {
           c.setValidators(() => {
             const v = Validators.compose(this.mergeValidators<ValidatorFn>(field, '_validators'));
 
             return v ? v(c) : null;
           });
-          c.setAsyncValidators(() => {
-            const v = Validators.composeAsync(this.mergeValidators<AsyncValidatorFn>(field, '_asyncValidators'));
-
-            return v ? v(c) : of(null);
-          });
 
           markForCheck = true;
+        }
+
+        if (null === c.asyncValidator) {
+          const asyncValidatorsList = this.mergeValidators<AsyncValidatorFn>(field, '_asyncValidators');
+
+          if (asyncValidatorsList.length) {
+            c.setAsyncValidators(() => {
+              const v = Validators.composeAsync(asyncValidatorsList);
+              return v ? v(c) : of(null);
+            });
+            markForCheck = true;
+          }
         }
 
         if (markForCheck) {


### PR DESCRIPTION
The array add operation was slow because the field build created an observable and set the asyncValidators, even when there were no async validators. This change checks if the async validators are present and then only sets them.

fix #3791

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Improves the performance of array add operation, mentioned in the issue #3791


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
