### PR TITLE
fix(bootstrap): update multicheckbox aria attr in input tag

### DIFF
--- a/src/ui/bootstrap/form-field/src/form-field.wrapper.ts
+++ b/src/ui/bootstrap/form-field/src/form-field.wrapper.ts
@@ -29,7 +29,11 @@ export interface FormlyFieldProps extends CoreFormlyFieldProps {
       </ng-container>
 
       <div *ngIf="showError" class="invalid-feedback" [style.display]="'block'">
-        <formly-validation-message id="{{ id }}-formly-validation-error" [field]="field"></formly-validation-message>
+        <formly-validation-message
+          id="{{ id }}-formly-validation-error"
+          [field]="field"
+          role="alert"
+        ></formly-validation-message>
       </div>
 
       <small *ngIf="props.description" class="form-text text-muted">{{ props.description }}</small>

--- a/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.spec.ts
+++ b/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.spec.ts
@@ -1,0 +1,77 @@
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
+import { FormlyBootstrapMultiCheckboxModule } from '@ngx-formly/bootstrap/multicheckbox';
+
+const renderComponent = (field: FormlyFieldConfig) => {
+  return createFieldComponent(field, {
+    imports: [FormlyBootstrapMultiCheckboxModule],
+  });
+};
+
+describe('ui-bootstrap: MultiCheckbox Type', () => {
+  it('should render multicheckbox type', () => {
+    const { query, queryAll } = renderComponent({
+      key: 'name',
+      type: 'multicheckbox',
+      props: {
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-form-field')).not.toBeNull();
+    expect(queryAll('input[type="checkbox"]')).toHaveLength(3);
+  });
+
+  it('should add "is-invalid" class and set aria-invalid to be true on invalid', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'multicheckbox',
+      validation: { show: true },
+      props: {
+        options: [{ value: 1, label: 'label 1' }],
+        required: true,
+      },
+    });
+
+    expect(query('input[type="checkbox"]').classes['is-invalid']).toBeTrue();
+    expect(query('input[type="checkbox"]').nativeElement.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('should bind control value on change', () => {
+    const changeSpy = jest.fn();
+    const { query, queryAll, field, detectChanges } = renderComponent({
+      key: 'name',
+      type: 'multicheckbox',
+      props: {
+        options: [
+          { value: 1, label: 'label 1' },
+          { value: 2, label: 'label 2' },
+          { value: 3, label: 'label 3' },
+        ],
+        change: changeSpy,
+      },
+    });
+    query('input[type="checkbox"]').triggerEventHandler('change', ɵCustomEvent({ checked: true }));
+    detectChanges();
+    expect(field.formControl.value).toEqual({ '1': true });
+    expect(changeSpy).toHaveBeenCalledOnce;
+
+    queryAll('input[type="checkbox"]').forEach((x) => {
+      x.triggerEventHandler('change', ɵCustomEvent({ checked: true }));
+      detectChanges();
+      console.log(field.form);
+    });
+
+    expect(field.formControl.value).toEqual({ '1': true, '2': true, '3': true });
+    expect(changeSpy).toHaveBeenCalledTimes(4);
+
+    query('input[type="checkbox"]').triggerEventHandler('change', ɵCustomEvent({ checked: false }));
+    detectChanges();
+    expect(field.formControl.value).toEqual({ '1': false, '2': true, '3': true });
+    expect(changeSpy).toHaveBeenCalledOnce;
+  });
+});

--- a/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.ts
+++ b/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.ts
@@ -21,8 +21,6 @@ export interface FormlyMultiCheckboxFieldConfig extends FormlyFieldConfig<MultiC
           'form-check-inline': props.formCheck === 'inline' || props.formCheck === 'inline-switch',
           'form-switch': props.formCheck === 'switch' || props.formCheck === 'inline-switch'
         }"
-        [attr.aria-describedby]="id + '-formly-validation-error'"
-        [attr.aria-invalid]="showError"
       >
         <input
           type="checkbox"
@@ -32,6 +30,8 @@ export interface FormlyMultiCheckboxFieldConfig extends FormlyFieldConfig<MultiC
           [checked]="isChecked(option)"
           [formlyAttributes]="field"
           [disabled]="formControl.disabled || option.disabled"
+          [attr.aria-describedby]="id + '-formly-validation-error'"
+          [attr.aria-invalid]="showError"
           (change)="onChange(option.value, $any($event.target).checked)"
         />
         <label class="form-check-label" [for]="id + '_' + i">

--- a/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.ts
+++ b/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.ts
@@ -26,6 +26,7 @@ export interface FormlyMultiCheckboxFieldConfig extends FormlyFieldConfig<MultiC
           type="checkbox"
           [id]="id + '_' + i"
           class="form-check-input"
+          [class.is-invalid]="showError"
           [value]="option.value"
           [checked]="isChecked(option)"
           [formlyAttributes]="field"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Commit 1: This bug fix is to have the aria-describedby and aria-isinvalid to be in the input tag and not the div tag for the multicheckbox form field.

Commit2: Added role tag to formly-validation-message. This lets a screen reader know to read out the message as it appears, instead of the second time visited.

Commit3: Added unit test for multicheckbox form field type. Added is-invalid class on showError.

**What is the current behavior? (You can also link to an open issue here)**
Input validation errors are not being read by screen reader when presented.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
