### PR TITLE
fix(core): fix array remove operation for array of oneOf

### DIFF
--- a/src/core/src/lib/templates/field-array.type.ts
+++ b/src/core/src/lib/templates/field-array.type.ts
@@ -52,12 +52,27 @@ export abstract class FieldArrayType<F extends FormlyFieldConfig = FieldArrayTyp
     markAsDirty && this.formControl.markAsDirty();
   }
 
+  updateArrayElementKey(f: FormlyFieldConfig, newKey: string) {
+    if (f.key) {
+      f.key = newKey;
+      return;
+    }
+
+    if (!f.fieldGroup?.length) {
+      return;
+    }
+
+    for (let i = 0; i < f.fieldGroup.length; i++) {
+      this.updateArrayElementKey(f.fieldGroup[i], newKey);
+    }
+  }
+
   remove(i: number, { markAsDirty } = { markAsDirty: true }) {
     this.model.splice(i, 1);
 
     const field = this.field.fieldGroup[i];
     this.field.fieldGroup.splice(i, 1);
-    this.field.fieldGroup.forEach((f, key) => (f.key = `${key}`));
+    this.field.fieldGroup.forEach((f, key) => this.updateArrayElementKey(f, `${key}`));
     unregisterControl(field, true);
     this._build();
     markAsDirty && this.formControl.markAsDirty();


### PR DESCRIPTION
fix #3794

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
PR fixes the issue of array remove operation failing when elements are oneOf

Issue: for enabling support of multi schema type elements in the array, we set the key as null but in remove operation we were reseting to the current index.



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
