### PR TITLE
feat(primeng): select filtering prop

### DIFF
--- a/demo/src/app/ui/ui-primeng/select/app.component.ts
+++ b/demo/src/app/ui/ui-primeng/select/app.component.ts
@@ -16,6 +16,7 @@ export class AppComponent {
       type: 'select',
       props: {
         label: 'Select',
+        filter: true,
         placeholder: 'Placeholder',
         description: 'Description',
         required: true,

--- a/src/ui/primeng/select/src/select.type.spec.ts
+++ b/src/ui/primeng/select/src/select.type.spec.ts
@@ -69,4 +69,31 @@ describe('ui-primeng: Select Type', () => {
     expect(field.formControl.value).toEqual(2);
     expect(changeSpy).toHaveBeenCalledOnce();
   });
+
+  it('should filter results on search', () => {
+    const { query, queryAll, fixture } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      props: {
+        label: 'Select',
+        filter: true,
+        options: [
+          { value: 1, label: 'apple label' },
+          { value: 2, label: 'apple-pie label' },
+          { value: 3, label: 'pie label' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-primeng-form-field')).not.toBeNull();
+    const inputQuery = 'p-dropdown input.p-dropdown-filter';
+
+    query('p-dropdown div').triggerEventHandler('click', ɵCustomEvent({ isSameNode: () => false }));
+    expect(queryAll('p-dropdownItem')).toHaveLength(3);
+
+    query(inputQuery).triggerEventHandler('input', { target: { value: 'pie' } });
+    fixture.detectChanges();
+    expect(queryAll('p-dropdownItem')).toHaveLength(2);
+    expect(queryAll('p-dropdownItem>li')[0].nativeElement.textContent).toEqual('apple-pie label');
+  });
 });

--- a/src/ui/primeng/select/src/select.type.ts
+++ b/src/ui/primeng/select/src/select.type.ts
@@ -5,6 +5,7 @@ import { FormlyFieldSelectProps } from '@ngx-formly/core/select';
 
 interface SelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
   appendTo?: any;
+  filter?: boolean;
 }
 
 export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> {
@@ -21,6 +22,7 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
       [formlyAttributes]="field"
       [showClear]="!props.required"
       [appendTo]="props.appendTo"
+      [filter]="props.filter"
       (onChange)="props.change && props.change(field, $event)"
     >
     </p-dropdown>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
New feature on PrimeNG select, adds the ability to enable search bar (filter property)
Filtering enabled on the demo page.

**What is the current behavior? (You can also link to an open issue here)**
Currently if using PrimeNG select with formly, search bar is not available


**What is the new behavior (if this is a feature change)?**
By adding the 
`filter: true`
property to the props object a basic search bar will now be enabled


**Please check if the PR fulfills these requirements**
- [X] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] A unit test has been written for this change.
- [X] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [X] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
