### PR TITLE
feat(material): simple strings as textPreffix/textSuffix for form-fields

### DIFF
--- a/demo/src/app/ui/ui-primeng/select/app.component.ts
+++ b/demo/src/app/ui/ui-primeng/select/app.component.ts
@@ -16,6 +16,7 @@ export class AppComponent {
       type: 'select',
       props: {
         label: 'Select',
+        filter: true,
         placeholder: 'Placeholder',
         description: 'Description',
         required: true,

--- a/src/ui/material/form-field/src/form-field.wrapper.ts
+++ b/src/ui/material/form-field/src/form-field.wrapper.ts
@@ -27,8 +27,8 @@ interface MatFormlyFieldConfig extends FormlyFieldConfig<FormlyFieldProps> {
 export interface FormlyFieldProps extends CoreFormlyFieldProps {
   prefix?: TemplateRef<any>;
   suffix?: TemplateRef<any>;
-  textPrefix?: TemplateRef<any>;
-  textSuffix?: TemplateRef<any>;
+  textPrefix?: TemplateRef<any> | string;
+  textSuffix?: TemplateRef<any> | string;
   hideLabel?: boolean;
   hideRequiredMarker?: boolean;
   hideFieldUnderline?: boolean;
@@ -63,7 +63,10 @@ export interface FormlyFieldProps extends CoreFormlyFieldProps {
       </mat-label>
 
       <ng-container matTextPrefix *ngIf="props.textPrefix">
-        <ng-container [ngTemplateOutlet]="props.textPrefix" [ngTemplateOutletContext]="{ field: field }"></ng-container>
+        <ng-container
+          [ngTemplateOutlet]="stringOrTemplate"
+          [ngTemplateOutletContext]="{ content: props.textPrefix }"
+        ></ng-container>
       </ng-container>
 
       <ng-container matPrefix *ngIf="props.prefix">
@@ -71,7 +74,10 @@ export interface FormlyFieldProps extends CoreFormlyFieldProps {
       </ng-container>
 
       <ng-container matTextSuffix *ngIf="props.textSuffix">
-        <ng-container [ngTemplateOutlet]="props.textSuffix" [ngTemplateOutletContext]="{ field: field }"></ng-container>
+        <ng-container
+          [ngTemplateOutlet]="stringOrTemplate"
+          [ngTemplateOutletContext]="{ content: props.textSuffix }"
+        ></ng-container>
       </ng-container>
 
       <ng-container matSuffix *ngIf="props.suffix">

--- a/src/ui/primeng/select/src/select.type.spec.ts
+++ b/src/ui/primeng/select/src/select.type.spec.ts
@@ -69,4 +69,31 @@ describe('ui-primeng: Select Type', () => {
     expect(field.formControl.value).toEqual(2);
     expect(changeSpy).toHaveBeenCalledOnce();
   });
+
+  it('should filter results on search', () => {
+    const { query, queryAll, fixture } = renderComponent({
+      key: 'name',
+      type: 'enum',
+      props: {
+        label: 'Select',
+        filter: true,
+        options: [
+          { value: 1, label: 'apple label' },
+          { value: 2, label: 'apple-pie label' },
+          { value: 3, label: 'pie label' },
+        ],
+      },
+    });
+
+    expect(query('formly-wrapper-primeng-form-field')).not.toBeNull();
+    const inputQuery = 'p-dropdown input.p-dropdown-filter';
+
+    query('p-dropdown div').triggerEventHandler('click', ɵCustomEvent({ isSameNode: () => false }));
+    expect(queryAll('p-dropdownItem')).toHaveLength(3);
+
+    query(inputQuery).triggerEventHandler('input', { target: { value: 'pie' } });
+    fixture.detectChanges();
+    expect(queryAll('p-dropdownItem')).toHaveLength(2);
+    expect(queryAll('p-dropdownItem>li')[0].nativeElement.textContent).toEqual('apple-pie label');
+  });
 });

--- a/src/ui/primeng/select/src/select.type.ts
+++ b/src/ui/primeng/select/src/select.type.ts
@@ -5,6 +5,7 @@ import { FormlyFieldSelectProps } from '@ngx-formly/core/select';
 
 interface SelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
   appendTo?: any;
+  filter?: boolean;
 }
 
 export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> {
@@ -21,6 +22,7 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
       [formlyAttributes]="field"
       [showClear]="!props.required"
       [appendTo]="props.appendTo"
+      [filter]="props.filter"
       (onChange)="props.change && props.change(field, $event)"
     >
     </p-dropdown>


### PR DESCRIPTION
Update form field wrapper to handle simple text in textPreffix/textSuffix

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Small feature for the form field wrapper


**What is the current behavior? (You can also link to an open issue here)**
The textPreffix and textSuffix options only accept templateRef, but the hint accept both strings and templateRef


**What is the new behavior (if this is a feature change)?**
The textPreffix and textSuffix options now handle both strings and templateRef (like the hint)


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
Didn't found any unit test for this part