### PR TITLE
fix(core): testing for NoopNgZone working in prod builds

### DIFF
--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { FormlyFieldConfig } from './models';
 import { isObservable } from 'rxjs';
 import { AbstractControl } from '@angular/forms';
 import { FormlyFieldConfigCache } from './models';
-import { ChangeDetectorRef, ComponentRef, NgZone, TemplateRef, Type } from '@angular/core';
+import { ChangeDetectorRef, ComponentRef, NgZone, TemplateRef, Type, ɵNoopNgZone } from '@angular/core';
 
 export function disableTreeValidityCall(form: any, callback: Function) {
   const _updateTreeValidity = form._updateTreeValidity.bind(form);
@@ -365,7 +365,7 @@ export function markFieldForCheck(field: FormlyFieldConfigCache) {
 }
 
 export function isNoopNgZone(ngZone: NgZone) {
-  return ngZone.constructor.name === 'NoopNgZone';
+  return ngZone instanceof ɵNoopNgZone;
 }
 
 export function isHiddenField(field: FormlyFieldConfig) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
detect model changes for zoneless change detection working in production builds

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/ngx-formly/ngx-formly/issues/3928

**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)
