### PR TITLE
docs(guides): typo in the custom types docs

### DIFF
--- a/docs/custom-formly-field.md
+++ b/docs/custom-formly-field.md
@@ -41,7 +41,7 @@ The live example can be found in stackblitz: [demo](https://stackblitz.com/edit/
   ### 2. Register the custom type in `NgModule` declaration:
 
   ```typescript
-  import { InputFieldType } from './intput-field.type';
+  import { InputFieldType } from './input-field.type';
 
   @NgModule({
     declarations: [InputFieldType],
@@ -54,7 +54,7 @@ The live example can be found in stackblitz: [demo](https://stackblitz.com/edit/
   > Note: This step is required only for JSON powered forms (see "Method-2" below).
 
   ```typescript
-  import { InputFieldType } from './intput-field.type';
+  import { InputFieldType } from './input-field.type';
 
   @NgModule({
     imports: [
@@ -78,7 +78,7 @@ The live example can be found in stackblitz: [demo](https://stackblitz.com/edit/
   * Method 1: Pass the `InputFieldType` component to the field config.
 
     ```typescript
-    import { InputFieldType } from './intput-field.type';
+    import { InputFieldType } from './input-field.type';
 
     export class AppComponent {
       fields: FormlyFieldConfig[] = [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update


**What is the current behavior? (You can also link to an open issue here)**
Typo in the file name `input-field.type` in custom types docs


**What is the new behavior (if this is a feature change)?**


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
