### PR TITLE
docs: fix JSON schema example app validation messages

### DIFF
--- a/demo/src/app/examples/advanced/json-schema/app.module.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.module.ts
@@ -40,11 +40,11 @@ export function multipleOfValidationMessage(error: any, field: FormlyFieldConfig
 }
 
 export function exclusiveMinimumValidationMessage(error: any, field: FormlyFieldConfig) {
-  return `should be > ${field.props.step}`;
+  return `should be > ${field.props.exclusiveMinimum}`;
 }
 
 export function exclusiveMaximumValidationMessage(error: any, field: FormlyFieldConfig) {
-  return `should be < ${field.props.step}`;
+  return `should be < ${field.props.exclusiveMaximum}`;
 }
 
 export function constValidationMessage(error: any, field: FormlyFieldConfig) {


### PR DESCRIPTION
Use the proper property names `exclusiveMinimum` and `exclusiveMaximum` instead of `step`

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
docs update

**What is the current behavior? (You can also link to an open issue here)**
Wrong parameter name used in functions `exclusiveMinimumValidationMessage` and `exclusiveMaximumValidationMessage`

**What is the new behavior (if this is a feature change)?**
Example app works properly

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Please provide a screenshot of this feature before and after your code changes, if applicable.**

**Other information**:
