### PR TITLE
fix(testing): mark components as standalone false

### DIFF
--- a/src/core/testing/src/component-factory.ts
+++ b/src/core/testing/src/component-factory.ts
@@ -112,6 +112,7 @@ export function createFieldComponent(
   selector: 'formly-test-component',
   template: '',
   providers: [FormlyFormBuilder],
+  standalone: false,
 })
 class TestComponent {
   constructor(public builder?: FormlyFormBuilder) {}

--- a/src/core/testing/src/input.module.ts
+++ b/src/core/testing/src/input.module.ts
@@ -6,6 +6,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 @Component({
   selector: 'formly-type-input',
   template: ` <input type="text" [formControl]="formControl" [formlyAttributes]="field" /> `,
+  standalone: false,
 })
 export class FormlyFieldInput extends FieldType<FieldTypeConfig> {}
 
@@ -18,6 +19,7 @@ export class FormlyFieldInput extends FieldType<FieldTypeConfig> {}
       <formly-validation-message [field]="field"></formly-validation-message>
     </ng-container>
   `,
+  standalone: false,
 })
 export class FormlyWrapperFormField extends FieldWrapper {}
 


### PR DESCRIPTION
> Note: Currently this changes produce build errors, as the workspace is still on Angular 13 which doesn't support the `standalone` component metadata just yet

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Closes #4020

**What is the new behavior (if this is a feature change)?**

The components in the testing entry point are explicitly marked as `standalone: false`, so they work in Angular 19.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
