### PR TITLE
fix: ensure compatibility with object keys minification

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -235,7 +235,7 @@ export class FormlyJsonschema {
         }
 
         if (schema.hasOwnProperty('exclusiveMinimum')) {
-          field.props.exclusiveMinimum = schema.exclusiveMinimum;
+          field.props['exclusiveMinimum'] = schema.exclusiveMinimum;
           this.addValidator(
             field,
             'exclusiveMinimum',
@@ -244,7 +244,7 @@ export class FormlyJsonschema {
         }
 
         if (schema.hasOwnProperty('exclusiveMaximum')) {
-          field.props.exclusiveMaximum = schema.exclusiveMaximum;
+          field.props['exclusiveMaximum'] = schema.exclusiveMaximum;
           this.addValidator(
             field,
             'exclusiveMaximum',
@@ -371,7 +371,7 @@ export class FormlyJsonschema {
       }
       case 'array': {
         if (schema.hasOwnProperty('minItems')) {
-          field.props.minItems = schema.minItems;
+          field.props['minItems'] = schema.minItems;
           this.addValidator(field, 'minItems', ({ value }: AbstractControl) => {
             return isEmpty(value) || value.length >= schema.minItems;
           });
@@ -380,13 +380,13 @@ export class FormlyJsonschema {
           }
         }
         if (schema.hasOwnProperty('maxItems')) {
-          field.props.maxItems = schema.maxItems;
+          field.props['maxItems'] = schema.maxItems;
           this.addValidator(field, 'maxItems', ({ value }: AbstractControl) => {
             return isEmpty(value) || value.length <= schema.maxItems;
           });
         }
         if (schema.hasOwnProperty('uniqueItems')) {
-          field.props.uniqueItems = schema.uniqueItems;
+          field.props['uniqueItems'] = schema.uniqueItems;
           this.addValidator(field, 'uniqueItems', ({ value }: AbstractControl) => {
             if (isEmpty(value) || !schema.uniqueItems) {
               return true;
@@ -451,7 +451,7 @@ export class FormlyJsonschema {
               f.props.required = true;
             }
             if (items[length]) {
-              f.props.removable = false;
+              f.props['removable'] = false;
             }
 
             return f;
@@ -462,7 +462,7 @@ export class FormlyJsonschema {
     }
 
     if (schema.hasOwnProperty('const')) {
-      field.props.const = schema.const;
+      field.props['const'] = schema.const;
       this.addValidator(field, 'const', ({ value }: AbstractControl) => value === schema.const);
       if (!field.type) {
         field.defaultValue = schema.const;
@@ -474,7 +474,7 @@ export class FormlyJsonschema {
       const multiple = field.type === 'array';
 
       field.type = 'enum';
-      field.props.multiple = multiple;
+      field.props['multiple'] = multiple;
       field.props.options = enumOptions;
 
       const enumValues = enumOptions.map((o) => o.value);

--- a/src/core/src/lib/components/formly.field.ts
+++ b/src/core/src/lib/components/formly.field.ts
@@ -161,13 +161,13 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
   }
 
   private triggerHook(name: keyof FormlyHookConfig, changes?: SimpleChanges) {
-    if (name === 'onInit' || (name === 'onChanges' && changes.field && !changes.field.firstChange)) {
+    if (name === 'onInit' || (name === 'onChanges' && changes['field'] && !changes['field'].firstChange)) {
       this.valueChangesUnsubscribe();
       this.valueChangesUnsubscribe = this.fieldChanges(this.field);
     }
 
     if (this.field?.hooks?.[name]) {
-      if (!changes || changes.field) {
+      if (!changes || changes['field']) {
         const r = this.field.hooks[name](this.field);
         if (isObservable(r) && ['onInit', 'afterContentInit', 'afterViewInit'].indexOf(name) !== -1) {
           const sub = r.subscribe();
@@ -176,8 +176,8 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
       }
     }
 
-    if (name === 'onChanges' && changes.field) {
-      this.resetRefs(changes.field.previousValue);
+    if (name === 'onChanges' && changes['field']) {
+      this.resetRefs(changes['field'].previousValue);
       this.render();
     }
   }

--- a/src/core/src/lib/components/formly.form.ts
+++ b/src/core/src/lib/components/formly.form.ts
@@ -98,11 +98,15 @@ export class FormlyForm implements DoCheck, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.fields && this.form) {
+    if (changes['fields'] && this.form) {
       clearControl(this.form);
     }
 
-    if (changes.fields || changes.form || (changes.model && this._modelChangeValue !== changes.model.currentValue)) {
+    if (
+      changes['fields'] ||
+      changes['form'] ||
+      (changes['model'] && this._modelChangeValue !== changes['model'].currentValue)
+    ) {
       this.valueChangesUnsubscribe();
       this.builder.build(this.field);
       this.valueChangesUnsubscribe = this.valueChanges();

--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -146,7 +146,7 @@ export class CoreExtension implements FormlyExtension {
 
     if (
       field.type !== 'formly-template' &&
-      (field.template || field.expressions?.template || field.expressionProperties?.template)
+      (field.template || field.expressions?.['template'] || field.expressionProperties?.['template'])
     ) {
       field.type = 'formly-template';
     }

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -36,7 +36,11 @@ export class FieldExpressionExtension implements FormlyExtension {
 
     if (field.hideExpression) {
       observe(field, ['hideExpression'], ({ currentValue: expr }) => {
-        field._expressions.hide = this.parseExpressions(field, 'hide', typeof expr === 'boolean' ? () => expr : expr);
+        field._expressions['hide'] = this.parseExpressions(
+          field,
+          'hide',
+          typeof expr === 'boolean' ? () => expr : expr,
+        );
       });
     }
 
@@ -185,7 +189,7 @@ export class FieldExpressionExtension implements FormlyExtension {
   private changeHideState(field: FormlyFieldConfigCache, hide: boolean, resetOnHide: boolean) {
     if (field.fieldGroup) {
       field.fieldGroup
-        .filter((f: FormlyFieldConfigCache) => f && !f._expressions.hide)
+        .filter((f: FormlyFieldConfigCache) => f && !f._expressions['hide'])
         .forEach((f) => this.changeHideState(f, hide, resetOnHide));
     }
 

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -1,9 +1,13 @@
-import { Type } from '@angular/core';
+import { ComponentRef, Type } from '@angular/core';
 import { ValidationErrors, AbstractControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { FormlyFieldConfig } from './fieldconfig';
 import { FieldType } from './../templates/field.type';
 import { FieldWrapper } from '../templates/field.wrapper';
+
+export declare interface FormlyFieldComponentRef {
+  _componentRef?: ComponentRef<any>;
+}
 
 export interface FormlyExtension<F extends FormlyFieldConfig = FormlyFieldConfig> {
   priority?: number;
@@ -13,7 +17,7 @@ export interface FormlyExtension<F extends FormlyFieldConfig = FormlyFieldConfig
   postPopulate?(field: F): void;
 }
 
-export interface TypeOption {
+export declare interface TypeOption {
   name: string;
   component?: Type<FieldType>;
   wrappers?: string[];

--- a/src/core/src/lib/models/fieldconfig.cache.ts
+++ b/src/core/src/lib/models/fieldconfig.cache.ts
@@ -5,10 +5,15 @@ import { FieldType } from '../templates/field.type';
 import { FormlyExtension } from './config';
 import { FormlyFieldConfig, FormlyFormOptions } from './fieldconfig';
 
-export interface FormlyFieldConfigCache extends FormlyFieldConfig {
+export declare interface FieldConfigWithErrors {
+  _fields?: FormlyFieldConfigCache[];
+  _childrenErrors?: { [id: string]: Function };
+}
+
+export declare interface FormlyFieldConfigCache extends FormlyFieldConfig {
   form?: FormGroup | FormArray;
   model?: any;
-  formControl?: AbstractControl & { _fields?: FormlyFieldConfigCache[]; _childrenErrors?: { [id: string]: Function } };
+  formControl?: AbstractControl & FieldConfigWithErrors;
   parent?: FormlyFieldConfigCache;
   options?: FormlyFormOptionsCache;
   shareFormControl?: boolean;
@@ -34,7 +39,7 @@ export interface FormlyFieldConfigCache extends FormlyFieldConfig {
   };
 }
 
-export interface FormlyFormOptionsCache extends FormlyFormOptions {
+export declare interface FormlyFormOptionsCache extends FormlyFormOptions {
   checkExpressions?: (field: FormlyFieldConfig, ingoreCache?: boolean) => void;
   _viewContainerRef?: ViewContainerRef;
   _injector?: Injector;

--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -20,7 +20,7 @@ type FieldExpressions = { [property: string]: FieldExpression } & {
   'props.required'?: FieldExpression<boolean>;
 };
 
-export interface FormlyFieldConfig<Props = FormlyFieldProps & { [additionalProperties: string]: any }> {
+export declare interface FormlyFieldConfig<Props = FormlyFieldProps & { [additionalProperties: string]: any }> {
   /**
    * The key that relates to the model. This will link the field value to the model
    */
@@ -256,7 +256,7 @@ export interface FormlyHookConfig {
   onDestroy?: FormlyHookFn;
 }
 
-export interface FormlyFormOptions {
+export declare interface FormlyFormOptions {
   updateInitialValue?: (model?: any) => void;
   resetModel?: (model?: any) => void;
   formState?: any;

--- a/src/core/src/lib/services/formly.builder.ts
+++ b/src/core/src/lib/services/formly.builder.ts
@@ -25,7 +25,7 @@ export class FormlyFormBuilder {
   }
 
   build(field: FormlyFieldConfig) {
-    if (!this.config.extensions.core) {
+    if (!this.config.extensions['core']) {
       throw new Error('NgxFormly: missing `forRoot()` call. use `forRoot()` when registering the `FormlyModule`.');
     }
 

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -9,6 +9,7 @@ import {
   ValidatorOption,
   WrapperOption,
   FormlyExtension,
+  FormlyFieldComponentRef,
   ValidationMessageOption,
   ExtensionOption,
   FormlyFieldConfigPresetProvider,
@@ -152,7 +153,7 @@ export class FormlyConfig {
 
   /** @ignore @internal */
   resolveFieldTypeRef(field: FormlyFieldConfigCache = {}): ComponentRef<FieldType> {
-    const type: TypeOption & { _componentRef?: ComponentRef<any> } = this.getType(field.type);
+    const type: TypeOption & FormlyFieldComponentRef = this.getType(field.type);
     if (!type) {
       return null;
     }

--- a/src/core/src/lib/templates/field-template.type.ts
+++ b/src/core/src/lib/templates/field-template.type.ts
@@ -13,7 +13,7 @@ export class FormlyTemplateType extends FieldType {
     if (this.field && this.field.template !== this.innerHtml.template) {
       this.innerHtml = {
         template: this.field.template,
-        content: this.props.safeHtml
+        content: this.props['safeHtml']
           ? this.sanitizer.bypassSecurityTrustHtml(this.field.template)
           : this.field.template,
       };

--- a/src/core/src/lib/templates/formly.attributes.ts
+++ b/src/core/src/lib/templates/formly.attributes.ts
@@ -67,7 +67,7 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.field) {
+    if (changes['field']) {
       this.field.name && this.setAttribute('name', this.field.name);
       this.uiEvents.listeners.forEach((listener) => listener());
       this.uiEvents.events.forEach((eventName) => {
@@ -94,8 +94,8 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
         });
       }
 
-      this.detachElementRef(changes.field.previousValue);
-      this.attachElementRef(changes.field.currentValue);
+      this.detachElementRef(changes['field'].previousValue);
+      this.attachElementRef(changes['field'].currentValue);
       if (this.fieldAttrElements.length === 1) {
         !this.id && this.field.id && this.setAttribute('id', this.field.id);
         this.focusObserver = observe<boolean>(this.field, ['focus'], ({ currentValue }) => {
@@ -104,7 +104,7 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
       }
     }
 
-    if (changes.id) {
+    if (changes['id']) {
       this.setAttribute('id', this.id);
     }
   }

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -227,7 +227,7 @@ export interface IObserver<T> {
   setValue: (value: T, emitEvent?: boolean) => void;
   unsubscribe: Function;
 }
-interface IObserveTarget<T> {
+declare interface IObserveTarget<T> {
   [prop: string]: any;
   _observers?: {
     [prop: string]: {


### PR DESCRIPTION
**What kind of change does this PR introduce? - Bug fix**

### Background:

While using advanced JavaScript compilers such as:
* **Google Closure Compiler** (Advanced Mode)
* **Terser** (with property mangling enabled)
* **Babel Minify** (with minify-mangle-names)
* **UglifyJS** (with mangle-props option) 

The current implementation of the library encounters issues due to direct property access `obj.key` being transformed during the compilation process. This results in runtime errors because object keys get minified or renamed by the compiler.

### Problem Statement:

In most cases, the current approach works well when defining interfaces in TypeScript. Consider the following example:

```
interface SomeInterface {
  someProperty: string;
}
```

Advanced JavaScript compilers like **Google Closure Compiler** or **Terser** analyze all usages of this interface and minify keys consistently across all instances:

```
interface SomeInterface {
  someProperty: string;
} 
// After compilation:
interface SomeInterface {
  dO: string; // Minified key
}
```

However, there are certain edge cases where this behavior causes runtime errors.

#### Root Cause:

The issue occurs when properties are minified but accessed later using a string literal key:

```
const foo: SomeInterface = { someProperty: 'prop' };

// After compilation:
console.log(foo);                  // Outputs: { dO: 'prop' }
console.log(foo['someProperty']);  // Outputs: undefined (key is minified)
```

Since the compiler renames `someProperty` to `dO`, any access using the original key `foo['someProperty']` will fail because the key no longer exists after minification.

A good example of when `defineHiddenProp` or `hasOwnProperty` are used:

```
export function defineHiddenProp(field: any, prop: string, defaultValue: any) {
  Object.defineProperty(field, prop, { enumerable: false, writable: true, configurable: true });
  field[prop] = defaultValue;
}

if (field.hasOwnProperty('fieldGroup') && !hasKey(field)) {
  defineHiddenProp(field, 'formControl', field.form);
} 
```

#### Proposed Solution:

To prevent this, TypeScript’s `declare` keyword should be used when defining interfaces:

```
declare interface SomeInterface {
  someProperty: string;
}
```

Using `declare` instructs the compiler not to minify properties in this interface, ensuring compatibility with advanced compilers. This change prevents key renaming and resolves potential runtime issues caused by minification.




**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


By applying this fix, `ngx-formly` will be more robust, supporting both standard and minified builds without risking property-access issues. Let me know if you need further clarification!
