### PR TITLE
fix: fix import paths

### DIFF
--- a/src/ui/primeng/textarea/src/textarea.module.ts
+++ b/src/ui/primeng/textarea/src/textarea.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormlyModule } from '@ngx-formly/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { InputTextareaModule } from 'primeng/inputtextarea';
+import { TextareaModule } from 'primeng/textarea';
 import { FormlyFormFieldModule } from '@ngx-formly/primeng/form-field';
 import { FormlyFieldTextArea } from './textarea.type';
 
@@ -11,7 +11,7 @@ import { FormlyFieldTextArea } from './textarea.type';
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    InputTextareaModule,
+    TextareaModule,
 
     FormlyFormFieldModule,
     FormlyModule.forChild({


### PR DESCRIPTION
primeng changes the path of inputtextmodule to textmodule