### PR TITLE
Fix non-published preset provider

### DIFF
--- a/src/core/preset/src/public_api.ts
+++ b/src/core/preset/src/public_api.ts
@@ -1,1 +1,2 @@
 export { FormlyPresetModule } from './preset.module';
+export { provideFormlyPreset } from './preset.config';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

The `provideFormlyPreset` is not present in the `core/preset` `public_api.ts` file and therefore cannot be imported to be used in the application/component providers.

**What is the new behavior (if this is a feature change)?**

`provideFormlyPreset` is now exported from the `public_api.ts` file

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
