### PR TITLE
fix(core): overwrite valueChanges without losing pipes when debounce

### DIFF
--- a/src/core/src/lib/components/formly.field.ts
+++ b/src/core/src/lib/components/formly.field.ts
@@ -348,7 +348,7 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
 
       const { updateOn, debounce } = field.modelOptions;
       if ((!updateOn || updateOn === 'change') && debounce?.default > 0) {
-        valueChanges = control.valueChanges.pipe(debounceTime(debounce.default));
+        valueChanges = valueChanges.pipe(debounceTime(debounce.default));
       }
 
       const sub = valueChanges.subscribe((value) => {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/ngx-formly/ngx-formly/issues/4033
When we add a `modelOptions.debounce` config to the field, we lose all previously applied pipes of the valueChanges variable.

**What is the new behavior (if this is a feature change)?**

All previous pipes are still applied.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
