### PR TITLE
Update json-schema.md

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -46,7 +46,7 @@ To adjust the generated `FormlyFieldConfig` use one of the following options:
   "format": "date-time",
 + "widget": {
 +   "formlyConfig": {
-+     "templateOptions": { "type": "datetime-local" }
++     "props": { "type": "datetime-local" }
 +   }
 + }
 }


### PR DESCRIPTION
fix: change 'templateOptions' to 'props' in json-schema.md to be align with Formly v6

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
