### PR TITLE
V7.0.0 alpha.1 primeng raido button fix

### DIFF
--- a/src/ui/primeng/radio/src/radio.type.ts
+++ b/src/ui/primeng/radio/src/radio.type.ts
@@ -23,7 +23,7 @@ export interface FormlyRadioFieldConfig extends FormlyFieldConfig<RadioProps> {
         [inputId]="id + index"
       >
       </p-radioButton>
-      <label [for]="id + index" class="ml-2">{{ props.label }}</label>
+      <label [for]="id + index" class="ml-2">{{ option.label }}</label>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix for PrimeNg

**What is the current behavior? (You can also link to an open issue here)**

https://github.com/ngx-formly/ngx-formly/issues/4070

**What is the new behavior (if this is a feature change)?**

Fixes typo to ensure options in the radio button group are using the appropriate label.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
