### PR TITLE
feat(core): remove deprecated options methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Formly is a dynamic (JSON powered) form library for Angular that brings unmatche
 
 | Angular version | Formly version         |
 | --------------- | ---------------------- |
-| Angular >= 16   | `@ngx-formly/core@7.x` |
+| Angular >= 18   | `@ngx-formly/core@7.x` |
 | Angular >= 13   | `@ngx-formly/core@6.x` |
 | Angular >= 7    | `@ngx-formly/core@5.x` |
 | Angular >= 6    | `@ngx-formly/core@4.x` |

--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -1,0 +1,13 @@
+UPGRADE FROM 6.0 to 7.0
+=======================
+- Formly V7 now requires Angular Version >= 18
+
+@ngx-formly/core
+----------------
+### 1. Remove deprecated `FormlyFormOptions` methods:
+ 
+| Deprecated Method | Replaced with      |
+| ----------------- | ------------------ |
+| `_markForCheck`   | `detectChanges`    |
+| `_buildForm`      | `build`            |
+| `_markForCheck`   | `checkExpressions` |

--- a/src/core/src/lib/extensions/core/core.ts
+++ b/src/core/src/lib/extensions/core/core.ts
@@ -88,11 +88,6 @@ export class CoreExtension implements FormlyExtension {
       options._hiddenFieldsForCheck = [];
     }
 
-    options._markForCheck = (f) => {
-      console.warn(`Formly: 'options._markForCheck' is deprecated since v6.0, use 'options.detectChanges' instead.`);
-      options.detectChanges(f);
-    };
-
     options._detectChanges = (f: FormlyFieldConfigCache) => {
       if (f._componentRefs) {
         markFieldForCheck(f);

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -92,10 +92,6 @@ export class FieldExpressionExtension implements FormlyExtension {
         }
         checkLocked = false;
       };
-      field.options._checkField = (f, ignoreCache) => {
-        console.warn(`Formly: 'options._checkField' is deprecated since v6.0, use 'options.checkExpressions' instead.`);
-        field.options.checkExpressions(f, ignoreCache);
-      };
     }
   }
 

--- a/src/core/src/lib/models/fieldconfig.cache.ts
+++ b/src/core/src/lib/models/fieldconfig.cache.ts
@@ -44,13 +44,4 @@ export interface FormlyFormOptionsCache extends FormlyFormOptions {
   _hiddenFieldsForCheck?: { field: FormlyFieldConfigCache; default?: boolean }[];
   _initialModel?: any;
   _detectChanges?: (field: FormlyFieldConfig) => void;
-
-  /** @deprecated */
-  _buildForm?: () => void;
-
-  /** @deprecated */
-  _checkField?: (field: FormlyFieldConfig, ingoreCache?: boolean) => void;
-
-  /** @deprecated */
-  _markForCheck?: (field: FormlyFieldConfig) => void;
 }

--- a/src/core/src/lib/services/formly.builder.spec.ts
+++ b/src/core/src/lib/services/formly.builder.spec.ts
@@ -28,7 +28,6 @@ describe('FormlyFormBuilder service', () => {
       expect.objectContaining({
         _viewContainerRef: null,
         _injector: null,
-        _buildForm: expect.any(Function),
         build: expect.any(Function),
       }),
     );
@@ -36,9 +35,7 @@ describe('FormlyFormBuilder service', () => {
     global.console = { ...global.console, warn: jest.fn() };
     jest.spyOn(builder, 'build');
     field.options.build(field);
-    field.options._buildForm();
-    expect(console.warn).toBeCalled();
-    expect(builder.build).toHaveBeenCalledTimes(2);
+    expect(builder.build).toHaveBeenCalledOnce();
   });
 
   it('should call extension during build call', () => {

--- a/src/core/src/lib/services/formly.builder.ts
+++ b/src/core/src/lib/services/formly.builder.ts
@@ -83,11 +83,6 @@ export class FormlyFormBuilder {
     }
 
     if (!options.build) {
-      options._buildForm = () => {
-        console.warn(`Formly: 'options._buildForm' is deprecated since v6.0, use 'options.build' instead.`);
-        this.build(field);
-      };
-
       options.build = (f: FormlyFieldConfig = field) => {
         this.build(f);
 


### PR DESCRIPTION
BREAKING CHANGE: Deprecated `FormlyFormOptions` methods has been removed: `_markForCheck`, `_buildForm` and `_markForCheck`.