### PR TITLE
refactor(ionic): remove redundant code in formly-field-ion-input

### DIFF
--- a/src/ui/ionic/input/src/input.type.ts
+++ b/src/ui/ionic/input/src/input.type.ts
@@ -12,20 +12,11 @@ export interface FormlyInputFieldConfig extends FormlyFieldConfig<InputProps> {
   selector: 'formly-field-ion-input',
   template: `
     <ion-input
-      *ngIf="props.type !== 'number'; else numberTmp"
       [type]="props.type || 'text'"
       [label]="props.label"
       [formControl]="formControl"
       [ionFormlyAttributes]="field"
     ></ion-input>
-    <ng-template #numberTmp>
-      <ion-input
-        type="number"
-        [label]="props.label"
-        [formControl]="formControl"
-        [ionFormlyAttributes]="field"
-      ></ion-input>
-    </ng-template>
   `,
   styles: [':host { display: inherit; }'],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
The old code that separates ion-input for number and non-number is now obsolete

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Refactor

**What is the new behavior (if this is a feature change)?**

Same with current behavior

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

