### PR TITLE
refactor(core+material): convert to built-in control flow

### DIFF
--- a/src/core/src/lib/templates/formly.group.ts
+++ b/src/core/src/lib/templates/formly.group.ts
@@ -5,7 +5,9 @@ import { FieldType, FieldGroupTypeConfig } from './field.type';
 @Component({
   selector: 'formly-group',
   template: `
-    <formly-field *ngFor="let f of field.fieldGroup" [field]="f"></formly-field>
+    @for (f of field.fieldGroup; track $index) {
+      <formly-field [field]="f"></formly-field>
+    }
     <ng-content></ng-content>
   `,
   host: {

--- a/src/core/testing/src/input.module.ts
+++ b/src/core/testing/src/input.module.ts
@@ -15,9 +15,9 @@ export class FormlyFieldInput extends FieldType<FieldTypeConfig> {}
   template: `
     <label [attr.for]="id">{{ props.label }}</label>
     <ng-template #fieldComponent></ng-template>
-    <ng-container *ngIf="showError">
+    @if (showError) {
       <formly-validation-message [field]="field"></formly-validation-message>
-    </ng-container>
+    }
   `,
   standalone: false,
 })

--- a/src/ui/material/checkbox/src/checkbox.type.ts
+++ b/src/ui/material/checkbox/src/checkbox.type.ts
@@ -36,12 +36,9 @@ export interface FormlyCheckboxFieldConfig extends FormlyFieldConfig<CheckboxPro
       [labelPosition]="props.labelPosition"
     >
       {{ props.label }}
-      <span
-        *ngIf="props.required && props.hideRequiredMarker !== true"
-        aria-hidden="true"
-        class="mat-form-field-required-marker mat-mdc-form-field-required-marker"
-        >*</span
-      >
+      @if (props.required && props.hideRequiredMarker !== true) {
+        <span aria-hidden="true" class="mat-form-field-required-marker mat-mdc-form-field-required-marker">*</span>
+      }
     </mat-checkbox>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/ui/material/form-field/src/form-field.wrapper.ts
+++ b/src/ui/material/form-field/src/form-field.wrapper.ts
@@ -52,52 +52,72 @@ export interface FormlyFieldProps extends CoreFormlyFieldProps {
       [color]="props.color ?? 'primary'"
     >
       <ng-container #fieldComponent></ng-container>
-      <mat-label *ngIf="props.label && props.hideLabel !== true">
-        {{ props.label }}
-        <span
-          *ngIf="props.required && props.hideRequiredMarker !== true"
-          aria-hidden="true"
-          class="mat-form-field-required-marker mat-mdc-form-field-required-marker"
-          >*</span
-        >
-      </mat-label>
+      @if (props.label && props.hideLabel !== true) {
+        <mat-label>
+          {{ props.label }}
+          @if (props.required && props.hideRequiredMarker !== true) {
+            <span aria-hidden="true" class="mat-form-field-required-marker mat-mdc-form-field-required-marker">*</span>
+          }
+        </mat-label>
+      }
 
-      <ng-container matTextPrefix *ngIf="props.textPrefix">
-        <ng-container [ngTemplateOutlet]="props.textPrefix" [ngTemplateOutletContext]="{ field: field }"></ng-container>
-      </ng-container>
+      @if (props.textPrefix) {
+        <ng-container
+          matTextPrefix
+          [ngTemplateOutlet]="props.textPrefix"
+          [ngTemplateOutletContext]="{ field: field }"
+        ></ng-container>
+      }
 
-      <ng-container matPrefix *ngIf="props.prefix">
-        <ng-container [ngTemplateOutlet]="props.prefix" [ngTemplateOutletContext]="{ field: field }"></ng-container>
-      </ng-container>
+      @if (props.prefix) {
+        <ng-container
+          matPrefix
+          [ngTemplateOutlet]="props.prefix"
+          [ngTemplateOutletContext]="{ field: field }"
+        ></ng-container>
+      }
 
-      <ng-container matTextSuffix *ngIf="props.textSuffix">
-        <ng-container [ngTemplateOutlet]="props.textSuffix" [ngTemplateOutletContext]="{ field: field }"></ng-container>
-      </ng-container>
+      @if (props.textSuffix) {
+        <ng-container
+          matTextSuffix
+          [ngTemplateOutlet]="props.textSuffix"
+          [ngTemplateOutletContext]="{ field: field }"
+        ></ng-container>
+      }
 
-      <ng-container matSuffix *ngIf="props.suffix">
-        <ng-container [ngTemplateOutlet]="props.suffix" [ngTemplateOutletContext]="{ field: field }"></ng-container>
-      </ng-container>
+      @if (props.suffix) {
+        <ng-container
+          matSuffix
+          [ngTemplateOutlet]="props.suffix"
+          [ngTemplateOutletContext]="{ field: field }"
+        ></ng-container>
+      }
 
       <mat-error>
         <formly-validation-message [field]="field"></formly-validation-message>
       </mat-error>
 
-      <mat-hint *ngIf="props.description || props.hintStart as hint">
-        <ng-container [ngTemplateOutlet]="stringOrTemplate" [ngTemplateOutletContext]="{ content: hint }">
-        </ng-container>
-      </mat-hint>
+      @if (props.description || props.hintStart; as hint) {
+        <mat-hint>
+          <ng-container [ngTemplateOutlet]="stringOrTemplate" [ngTemplateOutletContext]="{ content: hint }">
+          </ng-container>
+        </mat-hint>
+      }
 
-      <mat-hint *ngIf="props.hintEnd as hintEnd" align="end">
-        <ng-container [ngTemplateOutlet]="stringOrTemplate" [ngTemplateOutletContext]="{ content: hintEnd }">
-        </ng-container>
-      </mat-hint>
+      @if (props.hintEnd; as hintEnd) {
+        <mat-hint align="end">
+          <ng-container [ngTemplateOutlet]="stringOrTemplate" [ngTemplateOutletContext]="{ content: hintEnd }">
+          </ng-container>
+        </mat-hint>
+      }
     </mat-form-field>
 
     <ng-template #stringOrTemplate let-content="content">
-      <ng-container *ngIf="!content.createEmbeddedView; else template">{{ content }}</ng-container>
-      <ng-template #template>
+      @if (!content.createEmbeddedView) {
+        {{ content }}
+      } @else {
         <ng-container [ngTemplateOutlet]="content" [ngTemplateOutletContext]="{ field: field }"></ng-container>
-      </ng-template>
+      }
     </ng-template>
   `,
   styleUrls: ['./form-field.wrapper.scss'],

--- a/src/ui/material/input/src/input.type.ts
+++ b/src/ui/material/input/src/input.type.ts
@@ -11,21 +11,21 @@ export interface FormlyInputFieldConfig extends FormlyFieldConfig<InputProps> {
 @Component({
   selector: 'formly-field-mat-input',
   template: `
-    <input
-      *ngIf="type !== 'number'; else numberTmp"
-      matInput
-      [id]="id"
-      [name]="field.name"
-      [type]="type || 'text'"
-      [readonly]="props.readonly"
-      [required]="required"
-      [errorStateMatcher]="errorStateMatcher"
-      [formControl]="formControl"
-      [formlyAttributes]="field"
-      [tabIndex]="props.tabindex"
-      [placeholder]="props.placeholder"
-    />
-    <ng-template #numberTmp>
+    @if (type !== 'number') {
+      <input
+        matInput
+        [id]="id"
+        [name]="field.name"
+        [type]="type || 'text'"
+        [readonly]="props.readonly"
+        [required]="required"
+        [errorStateMatcher]="errorStateMatcher"
+        [formControl]="formControl"
+        [formlyAttributes]="field"
+        [tabIndex]="props.tabindex"
+        [placeholder]="props.placeholder"
+      />
+    } @else {
       <input
         matInput
         [id]="id"
@@ -39,7 +39,7 @@ export interface FormlyInputFieldConfig extends FormlyFieldConfig<InputProps> {
         [tabIndex]="props.tabindex"
         [placeholder]="props.placeholder"
       />
-    </ng-template>
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/ui/material/multicheckbox/src/multicheckbox.type.ts
+++ b/src/ui/material/multicheckbox/src/multicheckbox.type.ts
@@ -14,7 +14,7 @@ export interface FormlyMultiCheckboxFieldConfig extends FormlyFieldConfig<MultiC
 @Component({
   selector: 'formly-field-mat-multicheckbox',
   template: `
-    <ng-container *ngFor="let option of props.options | formlySelectOptions: field | async; let i = index">
+    @for (option of props.options | formlySelectOptions: field | async; track $index; let i = $index) {
       <mat-checkbox
         [id]="id + '_' + i"
         [formlyAttributes]="field"
@@ -27,7 +27,7 @@ export interface FormlyMultiCheckboxFieldConfig extends FormlyFieldConfig<MultiC
       >
         {{ option.label }}
       </mat-checkbox>
-    </ng-container>
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {

--- a/src/ui/material/native-select/src/native-select.type.ts
+++ b/src/ui/material/native-select/src/native-select.type.ts
@@ -22,21 +22,26 @@ export interface FormlyNativeSelectFieldConfig extends FormlyFieldConfig<NativeS
       [formControl]="formControl"
       [formlyAttributes]="field"
     >
-      <option *ngIf="props.placeholder" [ngValue]="undefined">{{ props.placeholder }}</option>
-      <ng-container *ngIf="props.options | formlySelectOptions: field | async as opts">
-        <ng-container *ngFor="let opt of opts">
-          <option *ngIf="!opt.group; else optgroup" [ngValue]="opt.value" [disabled]="opt.disabled">
-            {{ opt.label }}
-          </option>
-          <ng-template #optgroup>
+      @if (props.placeholder) {
+        <option [ngValue]="undefined">{{ props.placeholder }}</option>
+      }
+      @if (props.options | formlySelectOptions: field | async; as opts) {
+        @for (opt of opts; track $index) {
+          @if (!opt.group) {
+            <option [ngValue]="opt.value" [disabled]="opt.disabled">
+              {{ opt.label }}
+            </option>
+          } @else {
             <optgroup [label]="opt.label">
-              <option *ngFor="let child of opt.group" [ngValue]="child.value" [disabled]="child.disabled">
-                {{ child.label }}
-              </option>
+              @for (child of opt.group; track $index) {
+                <option [ngValue]="child.value" [disabled]="child.disabled">
+                  {{ child.label }}
+                </option>
+              }
             </optgroup>
-          </ng-template>
-        </ng-container>
-      </ng-container>
+          }
+        }
+      }
     </select>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/ui/material/radio/src/radio.type.ts
+++ b/src/ui/material/radio/src/radio.type.ts
@@ -20,16 +20,17 @@ export interface FormlyRadioFieldConfig extends FormlyFieldConfig<RadioProps> {
       [required]="required"
       [tabindex]="props.tabindex"
     >
-      <mat-radio-button
-        *ngFor="let option of props.options | formlySelectOptions: field | async; let i = index"
-        [id]="id + '_' + i"
-        [color]="props.color"
-        [labelPosition]="props.labelPosition"
-        [disabled]="option.disabled"
-        [value]="option.value"
-      >
-        {{ option.label }}
-      </mat-radio-button>
+      @for (option of props.options | formlySelectOptions: field | async; track $index; let i = $index) {
+        <mat-radio-button
+          [id]="id + '_' + i"
+          [color]="props.color"
+          [labelPosition]="props.labelPosition"
+          [disabled]="option.disabled"
+          [value]="option.value"
+        >
+          {{ option.label }}
+        </mat-radio-button>
+      }
     </mat-radio-group>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/ui/material/select/src/select.type.ts
+++ b/src/ui/material/select/src/select.type.ts
@@ -45,22 +45,25 @@ export interface FormlySelectFieldConfig extends FormlyFieldConfig<SelectProps> 
       [typeaheadDebounceInterval]="props.typeaheadDebounceInterval"
       [panelClass]="props.panelClass"
     >
-      <ng-container *ngIf="props.options | formlySelectOptions: field | async as selectOptions">
-        <ng-container
-          *ngIf="props.multiple && props.selectAllOption"
-          [ngTemplateOutlet]="selectAll"
-          [ngTemplateOutletContext]="{ selectOptions: selectOptions }"
-        >
-        </ng-container>
-        <ng-container *ngFor="let item of selectOptions">
-          <mat-optgroup *ngIf="item.group" [label]="item.label">
-            <mat-option *ngFor="let child of item.group" [value]="child.value" [disabled]="child.disabled">
-              {{ child.label }}
-            </mat-option>
-          </mat-optgroup>
-          <mat-option *ngIf="!item.group" [value]="item.value" [disabled]="item.disabled">{{ item.label }}</mat-option>
-        </ng-container>
-      </ng-container>
+      @if (props.options | formlySelectOptions: field | async; as selectOptions) {
+        @if (props.multiple && props.selectAllOption) {
+          <ng-container [ngTemplateOutlet]="selectAll" [ngTemplateOutletContext]="{ selectOptions: selectOptions }">
+          </ng-container>
+        }
+        @for (item of selectOptions; track $index) {
+          @if (item.group) {
+            <mat-optgroup [label]="item.label">
+              @for (child of item.group; track $index) {
+                <mat-option [value]="child.value" [disabled]="child.disabled">
+                  {{ child.label }}
+                </mat-option>
+              }
+            </mat-optgroup>
+          } @else {
+            <mat-option [value]="item.value" [disabled]="item.disabled">{{ item.label }}</mat-option>
+          }
+        }
+      }
     </mat-select>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactor to use built-in control flow for core and material, which was made stable in angular v18

**What is the current behavior? (You can also link to an open issue here)**
Uses *ngFor/*ngIf style control flow, which will be deprecated in angular v20

**What is the new behavior (if this is a feature change)?**
No change in behavior, except probably better performance

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
