### PR TITLE
feat(fieldconfig.ts): multiple

### DIFF
--- a/src/core/src/lib/models/fieldconfig.ts
+++ b/src/core/src/lib/models/fieldconfig.ts
@@ -222,6 +222,7 @@ export interface FormlyFieldProps {
   hidden?: boolean;
   max?: number;
   min?: number;
+  multiple?: boolean;
 
   minLength?: number;
   /** @deprecated use `minLength` */


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature


**What is the current behavior? (You can also link to an open issue here)**
`FormlyFieldProps` does not have the `multiple` attribute


**What is the new behavior (if this is a feature change)?**
Add `multiple?: boolean` to `FormlyFieldProps`


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Other information**:
Closes: https://github.com/ngx-formly/ngx-formly/issues/4127