### PR TITLE
fix: optional chain for validity.badInput

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -213,7 +213,7 @@ export class FormlyJsonschema {
                 typeof document !== 'undefined' && f.id
                   ? document.querySelector<HTMLInputElement>(`#${f.id}`)
                   : undefined;
-              if (input && !input.validity.badInput) {
+              if (input && !input.validity?.badInput) {
                 v = undefined;
               }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/ngx-formly/ngx-formly/issues/4131

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)