### PR TITLE
feat(core): extend formly json schema service to support if/then/else

### DIFF
--- a/demo/src/app/examples/advanced/json-schema/app.component.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.component.ts
@@ -36,6 +36,7 @@ export class AppComponent implements OnDestroy {
     'anyOf',
     'oneOf',
     'select_alternatives',
+    'if_then_else',
   ];
 
   constructor(

--- a/demo/src/app/examples/advanced/json-schema/app.routes.ts
+++ b/demo/src/app/examples/advanced/json-schema/app.routes.ts
@@ -116,6 +116,11 @@ export const appRoutes: Routes = [
               content: require('!!highlight-loader?raw=true&lang=typescript!@assets/json-schema/select_alternatives_json'),
               filecontent: require('!!raw-loader!@assets/json-schema/select_alternatives_json'),
             },
+            {
+              file: 'assets/json-schema/if_then_else.json',
+              content: require('!!highlight-loader?raw=true&lang=typescript!@assets/json-schema/if_then_else_json'),
+              filecontent: require('!!raw-loader!@assets/json-schema/if_then_else_json'),
+            },
           ],
         },
       ],

--- a/demo/src/assets/json-schema/if_then_else_json
+++ b/demo/src/assets/json-schema/if_then_else_json
@@ -1,0 +1,59 @@
+{
+  "schema": {
+    "title": "if/then/else",
+    "type": "object",
+    "properties": {
+      "street_address": {
+        "type": "string",
+        "title": "Street Address"
+      },
+      "country": {
+        "type": "string",
+        "title": "Country",
+        "default": "United States of America",
+        "enum": [
+          "United States of America",
+          "Canada",
+          "Other"
+        ]
+      }
+    },
+    "if": {
+      "properties": {
+        "country": {
+          "const": "United States of America"
+        }
+      }
+    },
+    "then": {
+      "properties": {
+        "zipcode": {
+          "type": "string",
+          "title": "ZIP Code",
+          "pattern": "[0-9]{5}(-[0-9]{4})?"
+        },
+        "state": {
+          "title": "State",
+          "type": "string"
+        }
+      }
+    },
+    "else": {
+      "properties": {
+        "postal_code": {
+          "title": "Postal Code",
+          "type": "string",
+          "pattern": "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]"
+        },
+        "province": {
+          "title": "Province",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "model": {
+    "street_address": "123 Main St",
+    "country": "United States of America"
+  }
+}

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -68,3 +68,60 @@ this.formlyJsonschema.toFieldConfig(
 +  },
 );
 ```
+## if/then/else
+
+The Formly JSON Schema service now supports conditional field rendering using the `if/then/else` keywords from JSON Schema 7.
+
+When a schema contains `if/then` or `if/else` conditions, Formly will:
+
+1. Parse the condition from the `if` schema (currently supports `{ "properties": { "propName": { "const": value } } }` pattern)
+2. Create field groups for the properties defined in `then` and/or `else`
+3. Add hide expressions to those field groups based on whether the condition is met
+4. Set `resetOnHide: true` on conditional fields so they don't persist when hidden
+
+### Example: If/Then/Else Together
+
+You can use both `then` and `else` in the same schema to show different fields based on a condition:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "street_address": {
+      "type": "string"
+    },
+    "country": {
+      "type": "string",
+      "default": "United States of America",
+      "enum": ["United States of America", "Canada", "Other"]
+    }
+  },
+  "if": {
+    "properties": {
+      "country": { "const": "United States of America" }
+    }
+  },
+  "then": {
+    "properties": {
+      "zipcode": { 
+        "type": "string",
+        "pattern": "[0-9]{5}(-[0-9]{4})?" 
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "postal_code": { 
+        "type": "string",
+        "pattern": "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]" 
+      }
+    }
+  }
+}
+```
+
+In this example:
+- When `country` is `"United States of America"`, the `zipcode` field is visible
+- When `country` is anything else (`"Canada"` or `"Other"`), the `postal_code` field is visible
+- Only one field will be visible at a time
+- Both fields will be reset when they become hidden


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature - extend formly json schema service to support if/then/else, part of the json schema v7 spec. Closes #3066

**What is the current behavior? (You can also link to an open issue here)**

It does not currently support if/then/else in json schema

**What is the new behavior (if this is a feature change)?**

It will now support if/then/else in json schema for conditional rendering of fields.
- extended formly-json-schema.service.ts
- added tests to formly-json-schema.service.spec.ts
- updated json-schema.md
- added if/then/else example to json schema examples

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Please provide a screenshot of this feature before and after your code changes, if applicable.**

<img width="1230" height="920" alt="image" src="https://github.com/user-attachments/assets/136190f5-0b7e-4c27-8b68-cc5995f4484f" />
<img width="1013" height="861" alt="image" src="https://github.com/user-attachments/assets/9a3564df-4708-4965-a5c5-7a1427a3e2ec" />


**Other information**:

n/a
