### PR TITLE
feat(core): support CSP-safe expression evaluation

### DIFF
--- a/src/core/src/lib/core.config.ts
+++ b/src/core/src/lib/core.config.ts
@@ -23,7 +23,7 @@ export function withDefaultConfig(config: FormlyConfig): ConfigOption {
       { name: 'core', extension: new CoreExtension(config), priority: -250 },
       { name: 'field-validation', extension: new FieldValidationExtension(config), priority: -200 },
       { name: 'field-form', extension: new FieldFormExtension(), priority: -150 },
-      { name: 'field-expression', extension: new FieldExpressionExtension(), priority: -100 },
+      { name: 'field-expression', extension: new FieldExpressionExtension(config), priority: -100 },
     ],
   };
 }

--- a/src/core/src/lib/extensions/field-expression/field-expression.ts
+++ b/src/core/src/lib/extensions/field-expression/field-expression.ts
@@ -10,7 +10,8 @@ import {
   assignFieldValue,
   hasKey,
 } from '../../utils';
-import { evalExpression, evalStringExpression } from './utils';
+import { evalExpression, evalStringExpression, evalStringExpressionLegacy } from './utils';
+import { FormlyConfig } from '../../services/formly.config';
 import { isObservable, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { FormlyExtension } from '../../models';
@@ -18,6 +19,8 @@ import { unregisterControl, registerControl, updateValidity } from '../field-for
 import { UntypedFormArray } from '@angular/forms';
 
 export class FieldExpressionExtension implements FormlyExtension {
+  constructor(private config: FormlyConfig) {}
+
   onPopulate(field: FormlyFieldConfigCache) {
     if (field._expressions) {
       return;
@@ -114,7 +117,12 @@ export class FieldExpressionExtension implements FormlyExtension {
 
     expr = expr || (() => false);
     if (typeof expr === 'string') {
-      expr = evalStringExpression(expr, ['model', 'formState', 'field']);
+      const exprString = expr;
+      if (this.config.extras.cspSafeExpressionEval) {
+        expr = evalStringExpression(exprString, ['model', 'formState', 'field']);
+      } else {
+        expr = evalStringExpressionLegacy(exprString, ['model', 'formState', 'field']);
+      }
     }
 
     let currentValue: any;

--- a/src/core/src/lib/extensions/field-expression/utils.spec.ts
+++ b/src/core/src/lib/extensions/field-expression/utils.spec.ts
@@ -1,9 +1,272 @@
-import { evalExpression } from './utils';
+import { evalExpression, evalStringExpression } from './utils';
 
 describe('evalExpression', () => {
   it('should evaluate the value correctly', () => {
     const model = { val: 2 };
     const expression = () => model.val;
     expect(evalExpression(expression, {}, [model])).toBe(2);
+  });
+});
+
+describe('evalStringExpression', () => {
+  describe('property access', () => {
+    it('should access model properties', () => {
+      const expr = evalStringExpression('model.name', ['model']);
+      expect(expr({ name: 'Marisol' })).toBe('Marisol');
+    });
+
+    it('should access nested properties', () => {
+      const expr = evalStringExpression('model.user.name', ['model']);
+      expect(expr({ user: { name: 'Asif' } })).toBe('Asif');
+    });
+
+    it('should access formState properties', () => {
+      const expr = evalStringExpression('formState.disabled', ['model', 'formState']);
+      expect(expr({}, { disabled: true })).toBe(true);
+    });
+
+    it('should access field properties', () => {
+      const expr = evalStringExpression('field.key', ['model', 'formState', 'field']);
+      expect(expr({}, {}, { key: 'email' })).toBe('email');
+    });
+
+    it('should handle bracket notation with strings', () => {
+      const expr = evalStringExpression('model["name"]', ['model']);
+      expect(expr({ name: 'Test' })).toBe('Test');
+    });
+
+    it('should handle bracket notation with numbers', () => {
+      const expr = evalStringExpression('model[0]', ['model']);
+      expect(expr(['first', 'second'])).toBe('first');
+    });
+
+    it('should return undefined for null/undefined properties', () => {
+      const expr = evalStringExpression('model.missing.nested', ['model']);
+      expect(expr({ missing: null })).toBeUndefined();
+    });
+  });
+
+  describe('comparison operators', () => {
+    it('should evaluate === operator', () => {
+      const expr = evalStringExpression('model.age === 25', ['model']);
+      expect(expr({ age: 25 })).toBe(true);
+      expect(expr({ age: 26 })).toBe(false);
+    });
+
+    it('should evaluate !== operator', () => {
+      const expr = evalStringExpression('model.status !== "active"', ['model']);
+      expect(expr({ status: 'inactive' })).toBe(true);
+      expect(expr({ status: 'active' })).toBe(false);
+    });
+
+    it('should evaluate < operator', () => {
+      const expr = evalStringExpression('model.count < 10', ['model']);
+      expect(expr({ count: 5 })).toBe(true);
+      expect(expr({ count: 15 })).toBe(false);
+    });
+
+    it('should evaluate <= operator', () => {
+      const expr = evalStringExpression('model.count <= 10', ['model']);
+      expect(expr({ count: 10 })).toBe(true);
+      expect(expr({ count: 11 })).toBe(false);
+    });
+
+    it('should evaluate > operator', () => {
+      const expr = evalStringExpression('model.count > 10', ['model']);
+      expect(expr({ count: 15 })).toBe(true);
+      expect(expr({ count: 5 })).toBe(false);
+    });
+
+    it('should evaluate >= operator', () => {
+      const expr = evalStringExpression('model.count >= 10', ['model']);
+      expect(expr({ count: 10 })).toBe(true);
+      expect(expr({ count: 9 })).toBe(false);
+    });
+  });
+
+  describe('logical operators', () => {
+    it('should evaluate && operator', () => {
+      const expr = evalStringExpression('model.a && model.b', ['model']);
+      expect(expr({ a: true, b: true })).toBe(true);
+      expect(expr({ a: true, b: false })).toBe(false);
+      expect(expr({ a: false, b: true })).toBe(false);
+    });
+
+    it('should evaluate || operator', () => {
+      const expr = evalStringExpression('model.a || model.b', ['model']);
+      expect(expr({ a: false, b: false })).toBe(false);
+      expect(expr({ a: true, b: false })).toBe(true);
+      expect(expr({ a: false, b: true })).toBe(true);
+    });
+
+    it('should evaluate ! operator', () => {
+      const expr = evalStringExpression('!model.disabled', ['model']);
+      expect(expr({ disabled: false })).toBe(true);
+      expect(expr({ disabled: true })).toBe(false);
+    });
+
+    it('should evaluate complex logical expressions', () => {
+      const expr = evalStringExpression('model.a && model.b || model.c', ['model']);
+      expect(expr({ a: true, b: true, c: false })).toBe(true);
+      expect(expr({ a: false, b: true, c: true })).toBe(true);
+      expect(expr({ a: false, b: false, c: false })).toBe(false);
+    });
+  });
+
+  describe('arithmetic operators', () => {
+    it('should evaluate addition', () => {
+      const expr = evalStringExpression('model.a + model.b', ['model']);
+      expect(expr({ a: 5, b: 3 })).toBe(8);
+    });
+
+    it('should evaluate subtraction', () => {
+      const expr = evalStringExpression('model.a - model.b', ['model']);
+      expect(expr({ a: 10, b: 4 })).toBe(6);
+    });
+
+    it('should evaluate multiplication', () => {
+      const expr = evalStringExpression('model.a * model.b', ['model']);
+      expect(expr({ a: 6, b: 7 })).toBe(42);
+    });
+
+    it('should evaluate division', () => {
+      const expr = evalStringExpression('model.a / model.b', ['model']);
+      expect(expr({ a: 20, b: 4 })).toBe(5);
+    });
+
+    it('should evaluate modulo', () => {
+      const expr = evalStringExpression('model.a % model.b', ['model']);
+      expect(expr({ a: 10, b: 3 })).toBe(1);
+    });
+
+    it('should handle negative numbers', () => {
+      const expr = evalStringExpression('-5 + model.a', ['model']);
+      expect(expr({ a: 10 })).toBe(5);
+    });
+
+    it('should handle negative number literals', () => {
+      const expr = evalStringExpression('model.a + -3', ['model']);
+      expect(expr({ a: 10 })).toBe(7);
+    });
+
+    it('should respect operator precedence (multiplication before addition)', () => {
+      const expr = evalStringExpression('model.a + model.b * model.c', ['model']);
+      expect(expr({ a: 2, b: 3, c: 4 })).toBe(14); // 2 + (3 * 4) = 14, not (2 + 3) * 4 = 20
+    });
+
+    it('should respect operator precedence (division before subtraction)', () => {
+      const expr = evalStringExpression('model.a - model.b / model.c', ['model']);
+      expect(expr({ a: 10, b: 8, c: 2 })).toBe(6); // 10 - (8 / 2) = 6, not (10 - 8) / 2 = 1
+    });
+
+    it('should handle parentheses to override precedence', () => {
+      const expr = evalStringExpression('(model.a + model.b) * model.c', ['model']);
+      expect(expr({ a: 2, b: 3, c: 4 })).toBe(20); // (2 + 3) * 4 = 20
+    });
+
+    it('should handle complex arithmetic expressions', () => {
+      const expr = evalStringExpression('model.a * 2 + model.b / 2 - model.c', ['model']);
+      expect(expr({ a: 5, b: 10, c: 3 })).toBe(12); // 5*2 + 10/2 - 3 = 10 + 5 - 3 = 12
+    });
+  });
+
+  describe('ternary operator', () => {
+    it('should evaluate ternary expressions', () => {
+      const expr = evalStringExpression('model.age >= 18 ? "adult" : "minor"', ['model']);
+      expect(expr({ age: 20 })).toBe('adult');
+      expect(expr({ age: 15 })).toBe('minor');
+    });
+
+    it('should handle nested ternary expressions', () => {
+      const expr = evalStringExpression('model.score >= 90 ? "A" : model.score >= 80 ? "B" : "C"', ['model']);
+      expect(expr({ score: 95 })).toBe('A');
+      expect(expr({ score: 85 })).toBe('B');
+      expect(expr({ score: 75 })).toBe('C');
+    });
+
+    it('should evaluate ternary with arithmetic', () => {
+      const expr = evalStringExpression('model.value > 0 ? model.value * 2 : model.value * -1', ['model']);
+      expect(expr({ value: 5 })).toBe(10);
+      expect(expr({ value: -5 })).toBe(5);
+    });
+  });
+
+  describe('literals', () => {
+    it('should handle string literals', () => {
+      const expr = evalStringExpression('"hello"', ['model']);
+      expect(expr({})).toBe('hello');
+    });
+
+    it('should handle number literals', () => {
+      const expr = evalStringExpression('42', ['model']);
+      expect(expr({})).toBe(42);
+    });
+
+    it('should handle decimal numbers', () => {
+      const expr = evalStringExpression('3.14', ['model']);
+      expect(expr({})).toBe(3.14);
+    });
+
+    it('should handle boolean literals', () => {
+      const expr1 = evalStringExpression('true', ['model']);
+      expect(expr1({})).toBe(true);
+
+      const expr2 = evalStringExpression('false', ['model']);
+      expect(expr2({})).toBe(false);
+    });
+
+    it('should handle null literal', () => {
+      const expr = evalStringExpression('null', ['model']);
+      expect(expr({})).toBe(null);
+    });
+
+    it('should handle undefined literal', () => {
+      const expr = evalStringExpression('undefined', ['model']);
+      expect(expr({})).toBeUndefined();
+    });
+  });
+
+  describe('mixed expressions', () => {
+    it('should handle comparison with arithmetic', () => {
+      const expr = evalStringExpression('model.price * 1.1 > 100', ['model']);
+      expect(expr({ price: 95 })).toBe(true); // 95 * 1.1 = 104.5 > 100
+      expect(expr({ price: 85 })).toBe(false); // 85 * 1.1 = 93.5 < 100
+    });
+
+    it('should handle logical operators with comparisons and arithmetic', () => {
+      const expr = evalStringExpression('model.age >= 18 && model.balance + model.deposit > 1000', ['model']);
+      expect(expr({ age: 20, balance: 800, deposit: 300 })).toBe(true);
+      expect(expr({ age: 16, balance: 800, deposit: 300 })).toBe(false);
+      expect(expr({ age: 20, balance: 500, deposit: 300 })).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return undefined for invalid expressions', () => {
+      const expr = evalStringExpression('invalid expression @#$', ['model']);
+      expect(expr).toBeUndefined();
+    });
+
+    it('should reject invalid number formats', () => {
+      const expr = evalStringExpression('1.2.3', ['model']);
+      expect(expr).toBeUndefined();
+    });
+
+    it('should handle expressions that result in runtime errors gracefully', () => {
+      const expr = evalStringExpression('model.a / 0', ['model']);
+      expect(expr({ a: 10 })).toBe(Infinity);
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('should handle expressions with various whitespace', () => {
+      const expr = evalStringExpression('  model.a   +   model.b  ', ['model']);
+      expect(expr({ a: 5, b: 3 })).toBe(8);
+    });
+
+    it('should handle expressions with no whitespace', () => {
+      const expr = evalStringExpression('model.a+model.b', ['model']);
+      expect(expr({ a: 5, b: 3 })).toBe(8);
+    });
   });
 });

--- a/src/core/src/lib/extensions/field-expression/utils.ts
+++ b/src/core/src/lib/extensions/field-expression/utils.ts
@@ -525,8 +525,22 @@ export function parseExpression(expression: string, argNames: string[]): any {
   }
 }
 
+/**
+ * Uses CSP-safe implementation
+ */
 export function evalStringExpression(expression: string, argNames: string[]): any {
   return parseExpression(expression, argNames);
+}
+
+/**
+ * Legacy implementation
+ */
+export function evalStringExpressionLegacy(expression: string, argNames: string[]): any {
+  try {
+    return Function(...argNames, `return ${expression};`) as any;
+  } catch (error) {
+    console.error(error);
+  }
 }
 
 export function evalExpression(

--- a/src/core/src/lib/extensions/field-expression/utils.ts
+++ b/src/core/src/lib/extensions/field-expression/utils.ts
@@ -1,9 +1,532 @@
-export function evalStringExpression(expression: string, argNames: string[]) {
-  try {
-    return Function(...argNames, `return ${expression};`) as any;
-  } catch (error) {
-    console.error(error);
+// CSP-compliant expression parser for Formly expressions
+// Supports: model.path, formState.path, field.path, comparisons, logical operators, and negation
+
+type ExpressionContext = {
+  model: any;
+  formState: any;
+  field: any;
+};
+
+// Tokenizer
+enum TokenType {
+  IDENTIFIER = 'IDENTIFIER',
+  DOT = 'DOT',
+  BRACKET_OPEN = 'BRACKET_OPEN',
+  BRACKET_CLOSE = 'BRACKET_CLOSE',
+  STRING = 'STRING',
+  NUMBER = 'NUMBER',
+  BOOLEAN = 'BOOLEAN',
+  NULL = 'NULL',
+  UNDEFINED = 'UNDEFINED',
+  OPERATOR = 'OPERATOR',
+  LOGICAL = 'LOGICAL',
+  NOT = 'NOT',
+  ARITHMETIC = 'ARITHMETIC',
+  PAREN_OPEN = 'PAREN_OPEN',
+  PAREN_CLOSE = 'PAREN_CLOSE',
+  TERNARY_QUESTION = 'TERNARY_QUESTION',
+  TERNARY_COLON = 'TERNARY_COLON',
+  EOF = 'EOF',
+}
+
+interface Token {
+  type: TokenType;
+  value: any;
+}
+
+class Tokenizer {
+  private pos = 0;
+  private input: string;
+
+  constructor(input: string) {
+    this.input = input.trim();
   }
+
+  tokenize(): Token[] {
+    const tokens: Token[] = [];
+
+    while (this.pos < this.input.length) {
+      this.skipWhitespace();
+
+      if (this.pos >= this.input.length) break;
+
+      const char = this.input[this.pos];
+
+      // String literals
+      if (char === '"' || char === "'") {
+        tokens.push(this.readString());
+      }
+      // Numbers
+      else if (/\d/.test(char)) {
+        tokens.push(this.readNumber());
+      }
+      // Identifiers and keywords
+      else if (/[a-zA-Z_$]/.test(char)) {
+        tokens.push(this.readIdentifier());
+      }
+      // Operators and symbols
+      else if (char === '.') {
+        tokens.push({ type: TokenType.DOT, value: '.' });
+        this.pos++;
+      } else if (char === '[') {
+        tokens.push({ type: TokenType.BRACKET_OPEN, value: '[' });
+        this.pos++;
+      } else if (char === ']') {
+        tokens.push({ type: TokenType.BRACKET_CLOSE, value: ']' });
+        this.pos++;
+      } else if (char === '(') {
+        tokens.push({ type: TokenType.PAREN_OPEN, value: '(' });
+        this.pos++;
+      } else if (char === ')') {
+        tokens.push({ type: TokenType.PAREN_CLOSE, value: ')' });
+        this.pos++;
+      } else if (char === '?') {
+        tokens.push({ type: TokenType.TERNARY_QUESTION, value: '?' });
+        this.pos++;
+      } else if (char === ':') {
+        tokens.push({ type: TokenType.TERNARY_COLON, value: ':' });
+        this.pos++;
+      } else if (char === '!') {
+        if (this.peek() === '=') {
+          if (this.input[this.pos + 2] === '=') {
+            tokens.push({ type: TokenType.OPERATOR, value: '!==' });
+            this.pos += 3;
+          } else {
+            tokens.push({ type: TokenType.OPERATOR, value: '!=' });
+            this.pos += 2;
+          }
+        } else {
+          tokens.push({ type: TokenType.NOT, value: '!' });
+          this.pos++;
+        }
+      } else if (char === '=' || char === '<' || char === '>') {
+        tokens.push(this.readOperator());
+      } else if (char === '+' || char === '*' || char === '/' || char === '%') {
+        tokens.push({ type: TokenType.ARITHMETIC, value: char });
+        this.pos++;
+      } else if (char === '-') {
+        // Check if this is a negative number or subtraction
+        // It's a negative number if preceded by an operator, opening paren, or at the start
+        const lastToken = tokens[tokens.length - 1];
+        const isNegativeNumber =
+          tokens.length === 0 ||
+          lastToken?.type === TokenType.OPERATOR ||
+          lastToken?.type === TokenType.LOGICAL ||
+          lastToken?.type === TokenType.ARITHMETIC ||
+          lastToken?.type === TokenType.PAREN_OPEN ||
+          lastToken?.type === TokenType.TERNARY_QUESTION ||
+          lastToken?.type === TokenType.TERNARY_COLON;
+
+        if (isNegativeNumber && this.peek() && /\d/.test(this.peek())) {
+          tokens.push(this.readNumber());
+        } else {
+          tokens.push({ type: TokenType.ARITHMETIC, value: '-' });
+          this.pos++;
+        }
+      } else if (char === '&' && this.peek() === '&') {
+        tokens.push({ type: TokenType.LOGICAL, value: '&&' });
+        this.pos += 2;
+      } else if (char === '|' && this.peek() === '|') {
+        tokens.push({ type: TokenType.LOGICAL, value: '||' });
+        this.pos += 2;
+      } else {
+        throw new Error(`Unexpected character: ${char} at position ${this.pos}`);
+      }
+    }
+
+    tokens.push({ type: TokenType.EOF, value: null });
+    return tokens;
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.input.length && /\s/.test(this.input[this.pos])) {
+      this.pos++;
+    }
+  }
+
+  private peek(offset = 1): string {
+    return this.input[this.pos + offset] || '';
+  }
+
+  private readString(): Token {
+    const quote = this.input[this.pos];
+    this.pos++;
+    let value = '';
+
+    while (this.pos < this.input.length && this.input[this.pos] !== quote) {
+      if (this.input[this.pos] === '\\') {
+        this.pos++;
+        if (this.pos < this.input.length) {
+          const escaped = this.input[this.pos];
+          switch (escaped) {
+            case 'n':
+              value += '\n';
+              break;
+            case 't':
+              value += '\t';
+              break;
+            case 'r':
+              value += '\r';
+              break;
+            default:
+              value += escaped;
+          }
+        }
+      } else {
+        value += this.input[this.pos];
+      }
+      this.pos++;
+    }
+
+    this.pos++; // skip closing quote
+    return { type: TokenType.STRING, value };
+  }
+
+  private readNumber(): Token {
+    let value = '';
+
+    // Handle negatives
+    if (this.input[this.pos] === '-') {
+      value += '-';
+      this.pos++;
+    }
+
+    let hasDecimal = false;
+    while (this.pos < this.input.length && /[\d.]/.test(this.input[this.pos])) {
+      if (this.input[this.pos] === '.') {
+        if (hasDecimal) {
+          throw new Error(`Invalid number format: multiple decimal points at position ${this.pos}`);
+        }
+        hasDecimal = true;
+      }
+      value += this.input[this.pos];
+      this.pos++;
+    }
+
+    const parsed = parseFloat(value);
+    if (isNaN(parsed)) {
+      throw new Error(`Invalid number format: ${value}`);
+    }
+
+    return { type: TokenType.NUMBER, value: parsed };
+  }
+
+  private readIdentifier(): Token {
+    let value = '';
+
+    while (this.pos < this.input.length && /[a-zA-Z0-9_$]/.test(this.input[this.pos])) {
+      value += this.input[this.pos];
+      this.pos++;
+    }
+
+    // Check for keywords
+    if (value === 'true' || value === 'false') {
+      return { type: TokenType.BOOLEAN, value: value === 'true' };
+    }
+    if (value === 'null') {
+      return { type: TokenType.NULL, value: null };
+    }
+    if (value === 'undefined') {
+      return { type: TokenType.UNDEFINED, value: undefined };
+    }
+
+    return { type: TokenType.IDENTIFIER, value };
+  }
+
+  private readOperator(): Token {
+    let op = this.input[this.pos];
+    this.pos++;
+
+    if (this.pos < this.input.length) {
+      const next = this.input[this.pos];
+      if (
+        (op === '=' && next === '=') ||
+        (op === '!' && next === '=') ||
+        (op === '<' && next === '=') ||
+        (op === '>' && next === '=')
+      ) {
+        op += next;
+        this.pos++;
+
+        // Check for === or !==
+        if (this.pos < this.input.length && this.input[this.pos] === '=') {
+          op += '=';
+          this.pos++;
+        }
+      }
+    }
+
+    return { type: TokenType.OPERATOR, value: op };
+  }
+}
+
+// Parser and Evaluator
+class ExpressionParser {
+  private tokens: Token[];
+  private pos = 0;
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens;
+  }
+
+  parse(): (context: ExpressionContext) => any {
+    const expr = this.parseTernary();
+    return (context: ExpressionContext) => expr(context);
+  }
+
+  private parseTernary(): (context: ExpressionContext) => any {
+    const expr = this.parseLogicalOr();
+
+    if (this.current().type === TokenType.TERNARY_QUESTION) {
+      this.consume(TokenType.TERNARY_QUESTION);
+      const trueExpr = this.parseLogicalOr();
+      this.consume(TokenType.TERNARY_COLON);
+      const falseExpr = this.parseTernary();
+
+      return (context: ExpressionContext) => {
+        return expr(context) ? trueExpr(context) : falseExpr(context);
+      };
+    }
+
+    return expr;
+  }
+
+  private parseLogicalOr(): (context: ExpressionContext) => any {
+    let left = this.parseLogicalAnd();
+
+    while (this.current().type === TokenType.LOGICAL && this.current().value === '||') {
+      this.consume(TokenType.LOGICAL);
+      const right = this.parseLogicalAnd();
+      const prevLeft = left;
+      left = (context: ExpressionContext) => prevLeft(context) || right(context);
+    }
+
+    return left;
+  }
+
+  private parseLogicalAnd(): (context: ExpressionContext) => any {
+    let left = this.parseComparison();
+
+    while (this.current().type === TokenType.LOGICAL && this.current().value === '&&') {
+      this.consume(TokenType.LOGICAL);
+      const right = this.parseComparison();
+      const prevLeft = left;
+      left = (context: ExpressionContext) => prevLeft(context) && right(context);
+    }
+
+    return left;
+  }
+
+  private parseComparison(): (context: ExpressionContext) => any {
+    const left = this.parseAdditive();
+
+    if (this.current().type === TokenType.OPERATOR) {
+      const op = this.consume(TokenType.OPERATOR).value;
+      const right = this.parseAdditive();
+
+      return (context: ExpressionContext) => {
+        const leftVal = left(context);
+        const rightVal = right(context);
+
+        switch (op) {
+          case '===':
+            return leftVal === rightVal;
+          case '!==':
+            return leftVal !== rightVal;
+          case '==':
+            return leftVal == rightVal;
+          case '!=':
+            return leftVal != rightVal;
+          case '<':
+            return leftVal < rightVal;
+          case '<=':
+            return leftVal <= rightVal;
+          case '>':
+            return leftVal > rightVal;
+          case '>=':
+            return leftVal >= rightVal;
+          default:
+            throw new Error(`Unknown operator: ${op}`);
+        }
+      };
+    }
+
+    return left;
+  }
+
+  private parseAdditive(): (context: ExpressionContext) => any {
+    let left = this.parseMultiplicative();
+
+    while (
+      this.current().type === TokenType.ARITHMETIC &&
+      (this.current().value === '+' || this.current().value === '-')
+    ) {
+      const op = this.consume(TokenType.ARITHMETIC).value;
+      const right = this.parseMultiplicative();
+      const prevLeft = left;
+
+      if (op === '+') {
+        left = (context: ExpressionContext) => prevLeft(context) + right(context);
+      } else {
+        left = (context: ExpressionContext) => prevLeft(context) - right(context);
+      }
+    }
+
+    return left;
+  }
+
+  private parseMultiplicative(): (context: ExpressionContext) => any {
+    let left = this.parseUnary();
+
+    while (
+      this.current().type === TokenType.ARITHMETIC &&
+      (this.current().value === '*' || this.current().value === '/' || this.current().value === '%')
+    ) {
+      const op = this.consume(TokenType.ARITHMETIC).value;
+      const right = this.parseUnary();
+      const prevLeft = left;
+
+      if (op === '*') {
+        left = (context: ExpressionContext) => prevLeft(context) * right(context);
+      } else if (op === '/') {
+        left = (context: ExpressionContext) => prevLeft(context) / right(context);
+      } else {
+        left = (context: ExpressionContext) => prevLeft(context) % right(context);
+      }
+    }
+
+    return left;
+  }
+
+  private parseUnary(): (context: ExpressionContext) => any {
+    if (this.current().type === TokenType.NOT) {
+      this.consume(TokenType.NOT);
+      const expr = this.parseUnary();
+      return (context: ExpressionContext) => !expr(context);
+    }
+
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): (context: ExpressionContext) => any {
+    const token = this.current();
+
+    // Parentheses
+    if (token.type === TokenType.PAREN_OPEN) {
+      this.consume(TokenType.PAREN_OPEN);
+      const expr = this.parseTernary();
+      this.consume(TokenType.PAREN_CLOSE);
+      return expr;
+    }
+
+    // Literals
+    if (
+      token.type === TokenType.STRING ||
+      token.type === TokenType.NUMBER ||
+      token.type === TokenType.BOOLEAN ||
+      token.type === TokenType.NULL ||
+      token.type === TokenType.UNDEFINED
+    ) {
+      const value = token.value;
+      this.pos++;
+      return () => value;
+    }
+
+    // Property access (model.field, formState.prop, etc)
+    if (token.type === TokenType.IDENTIFIER) {
+      return this.parsePropertyAccess();
+    }
+
+    throw new Error(`Unexpected token: ${JSON.stringify(token)}`);
+  }
+
+  private parsePropertyAccess(): (context: ExpressionContext) => any {
+    const path: Array<string | ((context: ExpressionContext) => any)> = [];
+
+    // Read first identifier
+    path.push(this.consume(TokenType.IDENTIFIER).value);
+
+    // Read rest of path (dots and brackets)
+    while (this.current().type === TokenType.DOT || this.current().type === TokenType.BRACKET_OPEN) {
+      if (this.current().type === TokenType.DOT) {
+        this.consume(TokenType.DOT);
+        path.push(this.consume(TokenType.IDENTIFIER).value);
+      } else {
+        this.consume(TokenType.BRACKET_OPEN);
+
+        // bracket notation can contain expressions
+        if (this.current().type === TokenType.STRING) {
+          path.push(this.consume(TokenType.STRING).value);
+        } else if (this.current().type === TokenType.NUMBER) {
+          path.push(String(this.consume(TokenType.NUMBER).value));
+        } else {
+          // dynamic property access
+          const expr = this.parseTernary();
+          path.push(expr);
+        }
+
+        this.consume(TokenType.BRACKET_CLOSE);
+      }
+    }
+
+    return (context: ExpressionContext) => {
+      let value: any = context;
+
+      for (const segment of path) {
+        if (value === null || value === undefined) {
+          return undefined;
+        }
+
+        if (typeof segment === 'function') {
+          value = value[segment(context)];
+        } else {
+          value = value[segment];
+        }
+      }
+
+      return value;
+    };
+  }
+
+  private current(): Token {
+    return this.tokens[this.pos];
+  }
+
+  private consume(expectedType: TokenType): Token {
+    const token = this.current();
+
+    if (token.type !== expectedType) {
+      throw new Error(`Expected ${expectedType}, got ${token.type}`);
+    }
+
+    this.pos++;
+    return token;
+  }
+}
+
+export function parseExpression(expression: string, argNames: string[]): any {
+  try {
+    const tokenizer = new Tokenizer(expression);
+    const tokens = tokenizer.tokenize();
+    const parser = new ExpressionParser(tokens);
+    const evaluator = parser.parse();
+
+    // Return a function that maps the args to the context
+    return (...args: any[]) => {
+      const context: any = {};
+      argNames.forEach((name, i) => {
+        context[name] = args[i];
+      });
+      return evaluator(context);
+    };
+  } catch (error) {
+    console.error('Expression parse error:', error);
+    return undefined;
+  }
+}
+
+export function evalStringExpression(expression: string, argNames: string[]): any {
+  return parseExpression(expression, argNames);
 }
 
 export function evalExpression(

--- a/src/core/src/lib/models/config.ts
+++ b/src/core/src/lib/models/config.ts
@@ -100,6 +100,14 @@ export interface ConfigOption {
      * Defaults to `true`.
      */
     renderFormlyFieldElement?: boolean;
+
+    /**
+     * When evaluating Formly Expressions, whether to parse the expression using
+     * new CSP-safe implementation (true) or legacy implementation (false)
+     *
+     * Defaults to `true`.
+     */
+    cspSafeExpressionEval?: boolean;
   };
   presets?: PresetOption[];
 }

--- a/src/core/src/lib/services/formly.config.ts
+++ b/src/core/src/lib/services/formly.config.ts
@@ -32,6 +32,7 @@ export class FormlyConfig {
     lazyRender: true,
     resetFieldOnHide: true,
     renderFormlyFieldElement: true,
+    cspSafeExpressionEval: true,
     showError(field: FieldType) {
       return (
         field.formControl?.invalid &&

--- a/src/core/testing/src/builder-factory.ts
+++ b/src/core/testing/src/builder-factory.ts
@@ -21,7 +21,7 @@ export function createBuilder({ extensions, onInit }: IBuilderOption = {}) {
       { name: 'core', extension: new CoreExtension(config) },
       { name: 'validation', extension: new FieldValidationExtension(config) },
       { name: 'form', extension: new FieldFormExtension() },
-      { name: 'expression', extension: new FieldExpressionExtension() },
+      { name: 'expression', extension: new FieldExpressionExtension(config) },
     ].filter(({ name }) => !extensions || extensions.includes(name)),
   });
   onInit && onInit(config);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR adds CSP-safe (no unsafe eval) expression parsing for use with formly expressions. This would close #2537

**What is the current behavior? (You can also link to an open issue here)**

Currently, expressions are evaluated by passing the string expression to a Function constructor, which violates the unsafe eval content security policy. 

**What is the new behavior (if this is a feature change)?**

Implemented a custom expression parser and evaluator that supports the same expression syntax without using dynamic code evaluation. The new implementation includes:

**Tokenizer**: Lexical analysis that breaks expressions into tokens. **Parser**: Recursive descent parser with proper operator precedence. **Evaluator**: Runtime evaluation using closure-based AST interpretation.

#### Supported Features

- ✅ Property access: `model.user.name`, `field.formControl.value`
- ✅ Nested properties: `model.user.address.city`
- ✅ Bracket notation: `model['property']`, `model[dynamicKey]`
- ✅ Comparison operators: `===`, `!==`, `==`, `!=`, `<`, `<=`, `>`, `>=`
- ✅ Logical operators: `&&`, `||`, `!`
- ✅ Arithmetic operators: `+`, `-`, `*`, `/`, `%` (with proper precedence)
- ✅ Ternary operators: `condition ? trueValue : falseValue`
- ✅ Literals: strings, numbers (including negative), booleans, null, undefined
- ✅ Parentheses for grouping: `(2 + 3) * 4`

#### Limitations

The parser intentionally does not support:

- ❌ Function calls or method invocations (e.g., `.toUpperCase()`, `.hasError()`)
- ❌ Array/object literals (`[1, 2, 3]`, `{ key: value }`)
- ❌ Assignment operators
- ❌ Spread operators or destructuring

These limitations maintain security while covering the common use cases in Formly expressions (property access, comparisons, and simple calculations).

#### Examples

```ts
// Property access with comparisons
'model.age >= 18 && model.consent === true'

// Arithmetic with proper precedence
'model.price * 1.1 > 100'  // Tax calculation
'(model.total + model.shipping) * 0.9'  // Discount calculation

// Complex ternary expressions
'model.country === "US" ? model.stateCode : model.province'
'model.items.length > 0 ? "Has items" : "Empty"'

// Negative numbers
'model.balance + -50'
'model.temperature < -10'
```

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
