### PR TITLE
fix(core): avoid p- InputNumber marking FormControl dirty

### DIFF
--- a/src/ui/primeng/input/src/formly-input-number.directive.spec.ts
+++ b/src/ui/primeng/input/src/formly-input-number.directive.spec.ts
@@ -1,0 +1,122 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { FieldType, FieldTypeConfig, FormlyAttributes, FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+import { InputNumber } from 'primeng/inputnumber';
+import { FormlyInputNumberDirective } from './formly-input-number.directive';
+
+describe('FormlyInputNumberDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let inputElement: HTMLInputElement;
+  let formControl: FormControl<number | null>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FormlyModule.forRoot(), TestHostComponent],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    inputElement = fixture.nativeElement.querySelector('input');
+    formControl = component.form.controls.number;
+  });
+
+  describe('should prevent marking control as dirty on blur without user input', () => {
+    it('should NOT mark control as dirty when user focuses and blurs without typing', fakeAsync(() => {
+      expect(formControl.pristine).toBe(true);
+      expect(formControl.dirty).toBe(false);
+
+      inputElement.dispatchEvent(new FocusEvent('focus'));
+      tick();
+      fixture.detectChanges();
+
+      inputElement.dispatchEvent(new FocusEvent('blur'));
+      tick();
+      fixture.detectChanges();
+
+      expect(formControl.dirty).toBe(false);
+      expect(formControl.pristine).toBe(true);
+    }));
+
+    it('should mark control as touched but NOT dirty after blur without input', fakeAsync(() => {
+      expect(formControl.touched).toBe(false);
+      expect(formControl.dirty).toBe(false);
+
+      inputElement.dispatchEvent(new FocusEvent('focus'));
+      tick();
+      inputElement.dispatchEvent(new FocusEvent('blur'));
+      tick();
+      fixture.detectChanges();
+
+      expect(formControl.touched).toBe(true);
+      expect(formControl.dirty).toBe(false);
+    }));
+  });
+
+  describe('should mark control as dirty when user types', () => {
+    it('should mark control as dirty after user input', fakeAsync(() => {
+      const inputNumberCmp = fixture.debugElement.query(By.directive(InputNumber)).componentInstance as InputNumber;
+
+      inputElement.dispatchEvent(new FocusEvent('focus'));
+      tick();
+      fixture.detectChanges();
+
+      inputElement.value = '100';
+
+      inputNumberCmp.onModelChange(100); // mark as dirty
+
+      tick();
+      fixture.detectChanges();
+
+      expect(formControl.dirty).toBe(true);
+    }));
+  });
+});
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'app-input-number-custom',
+  standalone: true,
+  imports: [ReactiveFormsModule, FormlyAttributes, InputNumber, FormlyInputNumberDirective],
+  template: `
+    <!-- prettier-ignore -->
+    <p-inputnumber fluid
+     [formControl]="formControl"
+     [formlyAttributes]="field"
+     [placeholder]="props.placeholder" />
+  `,
+})
+class InputNumberCustomComponent extends FieldType<FieldTypeConfig> {}
+
+@Component({
+  selector: 'formly-host',
+  standalone: true,
+  imports: [ReactiveFormsModule, FormlyModule, InputNumberCustomComponent],
+  template: `
+    <form [formGroup]="form">
+      <formly-form [form]="form" [fields]="fields" [model]="model" />
+    </form>
+  `,
+})
+class TestHostComponent {
+  form = new FormGroup({
+    number: new FormControl<number | null>(null),
+  });
+
+  model: { number?: number | null } = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'number',
+      type: InputNumberCustomComponent,
+      props: {
+        label: 'Test Number',
+        placeholder: 'Number input',
+      },
+    },
+  ];
+}

--- a/src/ui/primeng/input/src/formly-input-number.directive.ts
+++ b/src/ui/primeng/input/src/formly-input-number.directive.ts
@@ -55,7 +55,6 @@ export class FormlyInputNumberDirective implements OnInit {
 
       if (isSameValue && this.control.dirty && !this.userInteracted) {
         this.control.markAsPristine();
-        console.log('Control marked as pristine due to no user interaction');
       }
 
       this.lastValue = newNumericValue;

--- a/src/ui/primeng/input/src/formly-input-number.directive.ts
+++ b/src/ui/primeng/input/src/formly-input-number.directive.ts
@@ -1,0 +1,92 @@
+import { DestroyRef, Directive, ElementRef, inject, Input, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AbstractControl } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { EMPTY } from 'rxjs';
+
+/**
+ * Fix PrimeNG p-inputNumber marking control dirty on blur without user input.
+ * Import only in your PrimeNG input-number Formly type.
+ */
+@Directive({
+  selector: 'p-inputnumber[formControlName], p-inputnumber[formControl], p-inputnumber[formlyAttributes]',
+  standalone: true,
+})
+export class FormlyInputNumberDirective implements OnInit {
+  @Input() formlyAttributes?: FormlyFieldConfig;
+
+  private control?: AbstractControl;
+  private lastValue: number | null = null;
+  private userInteracted = false;
+
+  private readonly el = inject(ElementRef);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private get changes$() {
+    return this.control?.valueChanges ?? EMPTY;
+  }
+
+  ngOnInit(): void {
+    this.control = this.formlyAttributes?.formControl;
+    if (!this.control) return;
+
+    this.initLastValue();
+    this.subscribeToChanges();
+    this.registerListeners();
+  }
+
+  private initLastValue(): void {
+    this.lastValue = this.toNumber(this.control.value);
+  }
+
+  private subscribeToChanges(): void {
+    this.changes$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((newValue: unknown) => {
+      const newNumericValue = this.toNumber(newValue);
+      const isSameValue = this.areEqual(this.lastValue, newNumericValue);
+
+      if (isSameValue && this.control.dirty && !this.userInteracted) {
+        this.control.markAsPristine();
+      }
+
+      if (this.control.pristine && !isSameValue && this.userInteracted) {
+        this.control.markAsDirty();
+      }
+
+      this.lastValue = newNumericValue;
+    });
+  }
+
+  private registerListeners(): void {
+    const inputEl = this.el.nativeElement as HTMLInputElement;
+    const markAsInteracted = () => (this.userInteracted = true);
+
+    inputEl.addEventListener('input', markAsInteracted);
+    inputEl.addEventListener('focus', markAsInteracted);
+
+    this.destroyRef.onDestroy(() => {
+      inputEl.removeEventListener('input', markAsInteracted);
+      inputEl.removeEventListener('focus', markAsInteracted);
+    });
+  }
+
+  private toNumber(value: unknown): number | null {
+    if (value == null || value === '') {
+      return null;
+    }
+
+    const n = Number(value);
+    return Number.isNaN(n) ? null : n;
+  }
+
+  private areEqual(a: number | null, b: number | null): boolean {
+    if (a === b) {
+      return true;
+    }
+
+    if (a == null && b == null) {
+      return true;
+    }
+
+    return a === b;
+  }
+}

--- a/src/ui/primeng/input/src/input.module.ts
+++ b/src/ui/primeng/input/src/input.module.ts
@@ -7,6 +7,7 @@ import { FormlyFormFieldModule } from '@ngx-formly/primeng/form-field';
 
 import { FormlyFieldInput } from './input.type';
 import { withFormlyFieldInput } from './input.config';
+import { FormlyInputNumberDirective } from './formly-input-number.directive';
 
 @NgModule({
   declarations: [FormlyFieldInput],
@@ -15,6 +16,7 @@ import { withFormlyFieldInput } from './input.config';
     ReactiveFormsModule,
     InputTextModule,
     FormlyFormFieldModule,
+    FormlyInputNumberDirective,
     FormlyModule.forChild(withFormlyFieldInput()),
   ],
 })

--- a/src/ui/primeng/input/src/public_api.ts
+++ b/src/ui/primeng/input/src/public_api.ts
@@ -1,3 +1,4 @@
 export { withFormlyFieldInput } from './input.config';
 export { FormlyInputModule } from './input.module';
 export { FormlyFieldInput, FormlyInputFieldConfig } from './input.type';
+export * from './formly-input-number.directive';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix:  https://github.com/ngx-formly/ngx-formly/issues/4142

**What is the current behavior? (You can also link to an open issue here)**

When using PrimeNG p-inputNumber within Formly forms, the control is marked as dirty upon blur even if the user hasn’t changed the value.
This behavior differs from standard HTML inputs and causes validation and UI inconsistencies.

**What is the new behavior (if this is a feature change)?**

Introduces a lightweight standalone directive (FormlyInputNumberDirective) that prevents p-inputNumber controls from being marked dirty unless the user has actually interacted and changed the value.

**Please check if the PR fulfills these requirements**
 The commit messages follow the project’s contribution guidelines.

 Running npm run build produced a successful build.

 Code passes linting (npm run lint).


**Please provide a screenshot of this feature before and after your code changes, if applicable.**
<img width="482" height="227" alt="image" src="https://github.com/user-attachments/assets/10e81230-da6f-4ac2-83f5-442cbf138ca8" />



**Other information**:
Unit test is not present because i am waiting for feedback