### PR TITLE
feat(core): export FormlyFieldConfigPresetProvider via public_api

### DIFF
--- a/src/core/src/lib/core.ts
+++ b/src/core/src/lib/core.ts
@@ -7,6 +7,7 @@ export {
   FormlyFieldProps,
   ConfigOption,
   FormlyExtension,
+  FormlyFieldConfigPresetProvider,
 } from './models';
 export { LegacyFormlyField, FormlyField } from './components/formly.field';
 export { LegacyFormlyAttributes, FormlyAttributes } from './templates/formly.attributes';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

The FormlyFieldConfigPresetProvider interface was missing when trying to import it through "@ngx-formly/core".

**What is the current behavior? (You can also link to an open issue here)**

The FormlyFieldConfigPresetProvider interface needed to be imported via "@ngx-formly/core/lib/models".
Such import does not work depending on the TS version being used on an application project.

**What is the new behavior (if this is a feature change)?**

The FormlyFieldConfigPresetProvider can  be imported via "@ngx-formly/core/lib/models".

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
