### PR TITLE
fix(material): add aria-label for mat-radio-group

### DIFF
--- a/src/ui/material/radio/src/radio.type.spec.ts
+++ b/src/ui/material/radio/src/radio.type.spec.ts
@@ -58,4 +58,17 @@ describe('ui-material: Radio Type', () => {
     expect(field.formControl.value).toEqual(1);
     expect(changeSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('should add aria-label to mat-radio-group', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'radio',
+      props: {
+        label: 'hello world',
+        options: [{ value: 1, label: 'label 1' }],
+      },
+    });
+
+    expect(query('mat-radio-group').attributes['aria-label']).toEqual('hello world');
+  });
 });

--- a/src/ui/material/radio/src/radio.type.ts
+++ b/src/ui/material/radio/src/radio.type.ts
@@ -19,6 +19,7 @@ export interface FormlyRadioFieldConfig extends FormlyFieldConfig<RadioProps> {
       [formlyAttributes]="field"
       [required]="required"
       [tabindex]="props.tabindex"
+      [attr.aria-label]="props.label"
     >
       @for (option of props.options | formlySelectOptions: field | async; track $index; let i = $index) {
         <mat-radio-button


### PR DESCRIPTION
To ensure accessibility to users of screenreaders, added aria-label to mat-radio-group.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This ensures accessibility of mat-radio-group used by formly material. It introduces the `aria-label` attribute (filled from `props.label`, i.e. the label that is already displayed to sighted users) to ensure that users of screen readers can read the label of the radio group.

**What is the current behavior? (You can also link to an open issue here)**

Users of screen readers have to manually read the label text above the radio group and are not told it immediately on focusing the radio button.

**What is the new behavior (if this is a feature change)?**

Users of screen readers can read the label of the radio group when focusing it.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**

No visual change

**Other information**:
