### PR TITLE
fix(primeng): use pTextarea instead of deprecated pInputTextarea

### DIFF
--- a/src/ui/primeng/textarea/src/textarea.type.ts
+++ b/src/ui/primeng/textarea/src/textarea.type.ts
@@ -10,7 +10,7 @@ export interface FormlyTextAreaFieldConfig extends FormlyFieldConfig<TextAreaPro
 
 @Component({
   selector: 'formly-field-primeng-textarea',
-  template: ` <textarea [formControl]="formControl" [formlyAttributes]="field" pInputTextarea></textarea> `,
+  template: ` <textarea [formControl]="formControl" [formlyAttributes]="field" pTextarea></textarea> `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormlyFieldTextArea extends FieldType<FieldTypeConfig<TextAreaProps>> {}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
The PrimeNG textarea field (`formly-field-primeng-textarea`) still uses the deprecated `pInputTextarea` directive in its template.

This directive was used in older PrimeNG versions, but starting from PrimeNG v18 it has been replaced by `pTextarea`. As a result, the current implementation is outdated and does not align with the current PrimeNG API.

Related issues:
- #4037
- #4041

**What is the new behavior (if this is a feature change)?**
The textarea field now uses the `pTextarea` directive, aligning with the PrimeNG v18+ API.

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

**Please provide a screenshot of this feature before and after your code changes, if applicable.**

- Before
<img width="224" height="61" alt="image" src="https://github.com/user-attachments/assets/16317a13-7d2b-44d4-a980-7d562402e7cb" />

- After
<img width="338" height="109" alt="image" src="https://github.com/user-attachments/assets/8431a9df-f362-40a5-9751-b4f687e80eeb" />


**Other information**:
