### PR TITLE
fix(core): update model from inline template controls

### DIFF
--- a/src/core/src/lib/components/formly.field.ts
+++ b/src/core/src/lib/components/formly.field.ts
@@ -15,6 +15,7 @@ import {
   ElementRef,
   EmbeddedViewRef,
   Optional,
+  Injector,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { FormlyConfig } from '../services/formly.config';
@@ -78,6 +79,7 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
     private renderer: Renderer2,
     private _elementRef: ElementRef,
     private hostContainerRef: ViewContainerRef,
+    private injector: Injector,
     @Optional() private form: FormlyFieldTemplates,
   ) {}
 
@@ -152,7 +154,11 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
       const inlineType = this.form?.templates?.find((ref) => ref.name === f.type);
       let ref: ComponentRef<any> | EmbeddedViewRef<any>;
       if (inlineType) {
-        ref = containerRef.createEmbeddedView(inlineType.ref, { $implicit: f });
+        ref = containerRef.createEmbeddedView(
+          inlineType.ref,
+          { $implicit: f },
+          { injector: this.createFieldInjector() },
+        );
       } else {
         const { component } = this.config.getType(f.type, true);
         ref = containerRef.createComponent<FieldWrapper>(component as any);
@@ -181,6 +187,32 @@ export class FormlyField implements DoCheck, OnInit, OnChanges, AfterContentInit
       this.resetRefs(changes.field.previousValue);
       this.render();
     }
+  }
+
+  attachLocalField(field?: FormlyFieldConfigCache, previousField?: FormlyFieldConfigCache) {
+    const currentField = this.field as FormlyFieldConfigCache;
+    if (!currentField) {
+      return;
+    }
+
+    const localFields = (currentField._localFields || []).filter((f) => f !== field && f !== previousField);
+
+    if (field && field !== currentField) {
+      localFields.push(field);
+    }
+
+    if (currentField._localFields) {
+      currentField._localFields = localFields;
+    } else if (localFields.length > 0) {
+      defineHiddenProp(currentField, '_localFields', localFields);
+    }
+  }
+
+  private createFieldInjector() {
+    return Injector.create({
+      providers: [{ provide: FormlyField, useValue: this }],
+      parent: this.injector,
+    });
   }
 
   private attachComponentRef<T extends FieldType>(

--- a/src/core/src/lib/components/formly.form.spec.ts
+++ b/src/core/src/lib/components/formly.form.spec.ts
@@ -710,6 +710,41 @@ describe('FormlyForm Component', () => {
       expect(queryAll('.inline-group')).toHaveLength(3);
       expect(query('formly-group')).toBeNull();
     });
+
+    it('should update the model when rendering child controls in an inline group', () => {
+      const { model, query, detectChanges } = renderComponent(
+        {
+          model: { name: 'John Doe' },
+          fields: [
+            {
+              key: 'name',
+              type: 'input',
+            },
+          ],
+        },
+        {
+          template: `
+            <form [formGroup]="form">
+              <formly-form [form]="form" [fields]="fields" [model]="model">
+                <ng-template formlyTemplate let-field>
+                  <input
+                    id="inline-input"
+                    *ngFor="let f of field.fieldGroup"
+                    [formControl]="f.formControl"
+                    [formlyAttributes]="f"
+                  />
+                </ng-template>
+              </formly-form>
+            </form>
+          `,
+        },
+      );
+
+      query<HTMLInputElement>('#inline-input').triggerEventHandler('input', ɵCustomEvent({ value: 'Jane Doe' }));
+      detectChanges();
+
+      expect(model).toEqual({ name: 'Jane Doe' });
+    });
   });
 
   describe('formState update', () => {

--- a/src/core/src/lib/templates/formly.attributes.ts
+++ b/src/core/src/lib/templates/formly.attributes.ts
@@ -8,10 +8,12 @@ import {
   DoCheck,
   Inject,
   OnDestroy,
+  Optional,
 } from '@angular/core';
 import { FormlyFieldConfig, FormlyFieldConfigCache } from '../models';
 import { defineHiddenProp, FORMLY_VALIDATORS, observe, IObserver } from '../utils';
 import { DOCUMENT } from '@angular/common';
+import { FormlyField } from '../components/formly.field';
 
 /**
  * Allow to link the `field` HTML attributes (`id`, `name` ...) and Event attributes (`focus`, `blur` ...) to an element in the DOM.
@@ -67,6 +69,7 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
     private renderer: Renderer2,
     private elementRef: ElementRef,
     @Inject(DOCUMENT) _document: any,
+    @Optional() private formlyField?: FormlyField,
   ) {
     this.document = _document;
   }
@@ -99,8 +102,13 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
         });
       }
 
-      this.detachElementRef(changes.field.previousValue);
+      const previousField = changes.field.previousValue as FormlyFieldConfigCache;
+      this.detachElementRef(previousField);
       this.attachElementRef(changes.field.currentValue);
+      this.formlyField?.attachLocalField(
+        changes.field.currentValue as FormlyFieldConfigCache,
+        previousField?._elementRefs?.length ? undefined : previousField,
+      );
       if (this.fieldAttrElements.length === 1) {
         !this.id && this.field.id && this.setAttribute('id', this.field.id);
         this.focusObserver = observe<boolean>(this.field, ['focus'], ({ currentValue }) => {
@@ -150,6 +158,9 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
   ngOnDestroy() {
     this.uiEvents.listeners.forEach((listener) => listener());
     this.detachElementRef(this.field);
+    if (!(this.field as FormlyFieldConfigCache)?._elementRefs?.length) {
+      this.formlyField?.attachLocalField(undefined, this.field as FormlyFieldConfigCache);
+    }
     this.focusObserver?.unsubscribe();
   }
 
@@ -210,9 +221,10 @@ export class FormlyAttributes implements OnChanges, DoCheck, OnDestroy {
   }
 
   private detachElementRef(f: FormlyFieldConfigCache) {
-    const index = f?.['_elementRefs'] ? this.fieldAttrElements.indexOf(this.elementRef) : -1;
+    const elements = f?.['_elementRefs'] || [];
+    const index = elements.indexOf(this.elementRef);
     if (index !== -1) {
-      f['_elementRefs'].splice(index, 1);
+      elements.splice(index, 1);
     }
   }
 


### PR DESCRIPTION
## Summary
- Register controls rendered through inline `formlyTemplate` with the owning `FormlyField` so model updates are tracked.
- Pass the parent `FormlyField` through the inline template injector.
- Add regression coverage for manually rendered child controls with `[formControl]` and `[formlyAttributes]`.

## Root Cause
Custom inline group templates can render child field controls without creating child `<formly-field>` components. The controls update the Angular form, but Formly value-to-model subscriptions were never attached to those child fields.

## Impact
Models now stay in sync for custom inline group layouts like the PrimeFlex/PrimeNG template from #3869.

Fixes #3869

## Validation
- `npx jest src/core/src/lib --runInBand`
- `npx prettier --check src/core/src/lib/components/formly.field.ts src/core/src/lib/templates/formly.attributes.ts src/core/src/lib/components/formly.form.spec.ts`
- `npx eslint src/core/src/lib/components/formly.field.ts src/core/src/lib/templates/formly.attributes.ts src/core/src/lib/components/formly.form.spec.ts`
