### PR TITLE
feat(core): export FormlyAttributeEvent, ValidationMessageOption via public_api (#4095)

### DIFF
--- a/src/core/src/lib/core.ts
+++ b/src/core/src/lib/core.ts
@@ -8,6 +8,8 @@ export {
   ConfigOption,
   FormlyExtension,
   FormlyFieldConfigPresetProvider,
+  FormlyAttributeEvent,
+  ValidationMessageOption,
 } from './models';
 export { LegacyFormlyField, FormlyField } from './components/formly.field';
 export { LegacyFormlyAttributes, FormlyAttributes } from './templates/formly.attributes';


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

The FormlyAttributeEvent type and ValidationMessageOption interface were missing when trying to import it through "@ngx-formly/core".

**What is the current behavior? (You can also link to an open issue here)**

The FormlyAttributeEvent type and ValidationMessageOption interface needed to be imported via "@ngx-formly/core/lib/models". Such import does not work depending on the TS version being used on an application project.

Fixes: #4095

**What is the new behavior (if this is a feature change)?**

The FormlyAttributeEvent type and ValidationMessageOption interface can be imported via "@ngx-formly/core/lib/models".

**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
