### PR TITLE
fix(json-schema): pass anyOf mode for root-level anyOf (#4176)

### DIFF
--- a/src/core/json-schema/src/formly-json-schema.service.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.ts
@@ -546,7 +546,7 @@ export class FormlyJsonschema {
     if (schema.anyOf && !field.type) {
       delete field.key;
       field.fieldGroup = [
-        this.resolveMultiSchema('oneOf', <JSONSchema7[]>schema.anyOf, { ...options, key, shareFormControl: false }),
+        this.resolveMultiSchema('anyOf', <JSONSchema7[]>schema.anyOf, { ...options, key, shareFormControl: false }),
       ];
     }
 


### PR DESCRIPTION
Closes #4176.

In `resolveSchema`, the root-level `anyOf` branch was passing `'oneOf'` as the mode to `resolveMultiSchema`. The parallel object-level branch one block above (line 369) already uses `'anyOf'` correctly. The mode controls `multiple: mode === 'anyOf'` on the enum field (line 630) and value handling on selection change (lines 668, 674), so a root-level `anyOf` schema was rendered as a mutually-exclusive single-select instead of a multi-select.

One-character fix to align with the existing correct pattern at line 369. Matches the reporter's suggestion verbatim.