### PR TITLE
fix(core): detect select option observables with isObservable

### DIFF
--- a/src/core/select/src/select-options.pipe.spec.ts
+++ b/src/core/select/src/select-options.pipe.spec.ts
@@ -1,5 +1,5 @@
 import { FormlySelectOptionsPipe } from './select-options.pipe';
-import { of as observableOf, Subject } from 'rxjs';
+import { firstValueFrom, isObservable, Observable, of as observableOf, Subject } from 'rxjs';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { FormlyValueChangeEvent } from 'src/core/src/lib/models';
 
@@ -26,6 +26,22 @@ describe('Pipe: FormlySelectOptionsPipe', () => {
     pipe.transform(observableOf([{ label: '1', value: '1' }])).subscribe((options) => {
       expect(options).toEqual([{ label: '1', value: '1', disabled: false }]);
     });
+  });
+
+  it('passing options as an observable that is not an Observable instance', async () => {
+    const source = observableOf([{ label: '1', value: '1' }]);
+    const crossInstanceObservable = {
+      lift: source.lift.bind(source),
+      pipe: source.pipe.bind(source),
+      subscribe: source.subscribe.bind(source),
+    };
+
+    expect(crossInstanceObservable instanceof Observable).toBe(false);
+    expect(isObservable(crossInstanceObservable)).toBe(true);
+
+    await expect(firstValueFrom(pipe.transform(crossInstanceObservable))).resolves.toEqual([
+      { label: '1', value: '1', disabled: false },
+    ]);
   });
 
   it('should detect field expressions changes', () => {

--- a/src/core/select/src/select-options.pipe.ts
+++ b/src/core/select/src/select-options.pipe.ts
@@ -1,5 +1,5 @@
 import { OnDestroy, Pipe, PipeTransform } from '@angular/core';
-import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, isObservable, Observable, Subscription } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 import { FormlyFieldConfig, FormlyFieldProps } from '@ngx-formly/core';
 
@@ -30,7 +30,7 @@ export class FormlySelectOptionsPipe implements PipeTransform, OnDestroy {
   private _options: BehaviorSubject<any[]>;
 
   transform(options: any, field?: FormlyFieldConfig): Observable<FormlySelectOption[]> {
-    if (!(options instanceof Observable)) {
+    if (!isObservable(options)) {
       options = this.observableOf(options, field);
     } else {
       this.dispose();


### PR DESCRIPTION
## Summary

Fixes select option Observable detection across different RxJS instances.

## What changed

- Added regression coverage for an Observable-like value that is not an instance of the local RxJS `Observable` class.
- Updated `FormlySelectOptionsPipe` to use RxJS `isObservable` instead of `instanceof Observable`.

## Why

Issue #4173 reports that valid Observables from another RxJS instance can fail the `instanceof Observable` check and get treated as static options.

## Testing

- `npx jest src/core/select/src/select-options.pipe.spec.ts --runInBand`
- `npm run lint -- --quiet`
- `npm test -- --runInBand --silent`
- `git diff --check HEAD~1..HEAD`

Fixes #4173