### PR TITLE
refactor(testing): toBe logic & imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /out-tsc
 /hooks
 /integration/**/dist
+/demo/dist
 
 # Only exists if Bazel was run
 /bazel-out

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,78 +545,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@angular-eslint/builder/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@angular-eslint/builder/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@angular-eslint/builder/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/@angular-eslint/builder/node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@angular-eslint/builder/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -749,48 +677,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@angular-eslint/schematics/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@angular-eslint/schematics/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@angular-eslint/schematics/node_modules/magic-string": {
       "version": "0.30.11",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
@@ -799,36 +685,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "node_modules/@angular-eslint/schematics/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/@angular-eslint/schematics/node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/rxjs": {
@@ -8530,46 +8386,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@schematics/angular/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@schematics/angular/node_modules/magic-string": {
       "version": "0.30.11",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
@@ -8577,34 +8393,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@schematics/angular/node_modules/rxjs": {

--- a/src/core/json-schema/src/formly-json-schema.service.spec.ts
+++ b/src/core/json-schema/src/formly-json-schema.service.spec.ts
@@ -1,9 +1,9 @@
-import { FormlyJsonschema } from './formly-json-schema.service';
-import { JSONSchema7 } from 'json-schema';
-import { FormlyFieldConfig, FormlyFieldProps, FieldArrayType } from '@ngx-formly/core';
-import { FormControl, FormGroup, FormArray } from '@angular/forms';
-import { createComponent, FormlyInputModule, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { Component } from '@angular/core';
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
+import { FieldArrayType, FormlyFieldConfig, FormlyFieldProps } from '@ngx-formly/core';
+import { createComponent, FormlyInputModule, ɵCustomEvent } from '@ngx-formly/core/testing';
+import { JSONSchema7 } from 'json-schema';
+import { FormlyJsonschema } from './formly-json-schema.service';
 
 const renderComponent = ({ schema, model }: { schema: JSONSchema7; model?: any }) => {
   const field = new FormlyJsonschema().toFieldConfig(schema);
@@ -101,9 +101,9 @@ describe('Service: FormlyJsonschema', () => {
 
         const exclusiveMinimum = config.validators.exclusiveMinimum;
         expect(exclusiveMinimum).toBeDefined();
-        expect(exclusiveMinimum(new FormControl(4))).toBeFalse();
-        expect(exclusiveMinimum(new FormControl(5))).toBeFalse();
-        expect(exclusiveMinimum(new FormControl(6))).toBeTrue();
+        expect(exclusiveMinimum(new FormControl(4))).toBe(false);
+        expect(exclusiveMinimum(new FormControl(5))).toBe(false);
+        expect(exclusiveMinimum(new FormControl(6))).toBe(true);
       });
 
       it('should support exclusiveMaximum', () => {
@@ -115,9 +115,9 @@ describe('Service: FormlyJsonschema', () => {
 
         const exclusiveMaximum = config.validators.exclusiveMaximum;
         expect(exclusiveMaximum).toBeDefined();
-        expect(exclusiveMaximum(new FormControl(10))).toBeFalse();
-        expect(exclusiveMaximum(new FormControl(11))).toBeFalse();
-        expect(exclusiveMaximum(new FormControl(6))).toBeTrue();
+        expect(exclusiveMaximum(new FormControl(10))).toBe(false);
+        expect(exclusiveMaximum(new FormControl(11))).toBe(false);
+        expect(exclusiveMaximum(new FormControl(6))).toBe(true);
       });
 
       it('should support multipleOf', () => {
@@ -130,8 +130,8 @@ describe('Service: FormlyJsonschema', () => {
 
         const multipleOfValidator = config.validators.multipleOf;
         expect(multipleOfValidator).toBeDefined();
-        expect(multipleOfValidator(new FormControl(9))).toBeFalse();
-        expect(multipleOfValidator(new FormControl(10))).toBeTrue();
+        expect(multipleOfValidator(new FormControl(9))).toBe(false);
+        expect(multipleOfValidator(new FormControl(10))).toBe(true);
       });
 
       it('should support passing float multipleOf', () => {
@@ -144,41 +144,41 @@ describe('Service: FormlyJsonschema', () => {
 
         const multipleOfValidator = config.validators.multipleOf;
         expect(multipleOfValidator).toBeDefined();
-        expect(multipleOfValidator(new FormControl(0))).toBeTrue();
-        expect(multipleOfValidator(new FormControl(1))).toBeFalse();
-        expect(multipleOfValidator(new FormControl(10))).toBeFalse();
-        expect(multipleOfValidator(new FormControl(15))).toBeTrue();
+        expect(multipleOfValidator(new FormControl(0))).toBe(true);
+        expect(multipleOfValidator(new FormControl(1))).toBe(false);
+        expect(multipleOfValidator(new FormControl(10))).toBe(false);
+        expect(multipleOfValidator(new FormControl(15))).toBe(true);
         // rounding issues (15.30/0.15 = 102.00000000000001)
-        expect(multipleOfValidator(new FormControl(15.3))).toBeTrue();
-        expect(multipleOfValidator(new FormControl(150))).toBeTrue();
+        expect(multipleOfValidator(new FormControl(15.3))).toBe(true);
+        expect(multipleOfValidator(new FormControl(150))).toBe(true);
       });
 
       it('should be a number value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: 'number' });
-        expect(validateType(f, 5)).toBeTrue();
-        expect(validateType(f, 1.5)).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, '1')).toBeFalse();
-        expect(validateType(f, null)).toBeFalse();
+        expect(validateType(f, 5)).toBe(true);
+        expect(validateType(f, 1.5)).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, '1')).toBe(false);
+        expect(validateType(f, null)).toBe(false);
       });
 
       it('should be an integer value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: 'integer' });
-        expect(validateType(f, 5)).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, 1.5)).toBeFalse();
-        expect(validateType(f, '1')).toBeFalse();
-        expect(validateType(f, null)).toBeFalse();
+        expect(validateType(f, 5)).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, 1.5)).toBe(false);
+        expect(validateType(f, '1')).toBe(false);
+        expect(validateType(f, null)).toBe(false);
       });
     });
 
     describe('null type', () => {
       it('should be a null value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: 'null' });
-        expect(validateType(f, null)).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, '1')).toBeFalse();
-        expect(validateType(f, 5)).toBeFalse();
+        expect(validateType(f, null)).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, '1')).toBe(false);
+        expect(validateType(f, 5)).toBe(false);
       });
     });
 
@@ -218,18 +218,18 @@ describe('Service: FormlyJsonschema', () => {
 
       it('should be a string value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: 'string' });
-        expect(validateType(f, '1')).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, null)).toBeFalse();
-        expect(validateType(f, 5)).toBeFalse();
+        expect(validateType(f, '1')).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, null)).toBe(false);
+        expect(validateType(f, 5)).toBe(false);
       });
 
       it('should be a string or null value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: ['string', 'null'] });
-        expect(validateType(f, '1')).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, null)).toBeTrue();
-        expect(validateType(f, 5)).toBeFalse();
+        expect(validateType(f, '1')).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, null)).toBe(true);
+        expect(validateType(f, 5)).toBe(false);
       });
     });
 
@@ -238,11 +238,11 @@ describe('Service: FormlyJsonschema', () => {
     describe('array validation keywords', () => {
       it('should be an array value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: 'array' });
-        expect(validateType(f, ['sss'])).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, null)).toBeFalse();
-        expect(validateType(f, 5)).toBeFalse();
-        expect(validateType(f, {})).toBeFalse();
+        expect(validateType(f, ['sss'])).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, null)).toBe(false);
+        expect(validateType(f, 5)).toBe(false);
+        expect(validateType(f, {})).toBe(false);
       });
 
       it('supports array items keyword as object', () => {
@@ -367,11 +367,11 @@ describe('Service: FormlyJsonschema', () => {
         expect(config.props.minItems).toBe(numSchema.minItems);
 
         const minItemsValidator = (model: any) => config.validators.minItems(new FormControl(model), { model });
-        expect(minItemsValidator(undefined)).toBeTrue();
-        expect(minItemsValidator([1])).toBeFalse();
-        expect(minItemsValidator([])).toBeFalse();
-        expect(minItemsValidator([1, 2])).toBeTrue();
-        expect(minItemsValidator([1, 2, 3])).toBeTrue();
+        expect(minItemsValidator(undefined)).toBe(true);
+        expect(minItemsValidator([1])).toBe(false);
+        expect(minItemsValidator([])).toBe(false);
+        expect(minItemsValidator([1, 2])).toBe(true);
+        expect(minItemsValidator([1, 2, 3])).toBe(true);
       });
 
       it('minItems: should set default value', () => {
@@ -406,10 +406,10 @@ describe('Service: FormlyJsonschema', () => {
         expect(config.props.maxItems).toBe(numSchema.maxItems);
 
         const maxItemsValidator = (model: any) => config.validators.maxItems(new FormControl(model), { model });
-        expect(maxItemsValidator(undefined)).toBeTrue();
-        expect(maxItemsValidator([1, 2, 3])).toBeFalse();
-        expect(maxItemsValidator([1, 2])).toBeTrue();
-        expect(maxItemsValidator([])).toBeTrue();
+        expect(maxItemsValidator(undefined)).toBe(true);
+        expect(maxItemsValidator([1, 2, 3])).toBe(false);
+        expect(maxItemsValidator([1, 2])).toBe(true);
+        expect(maxItemsValidator([])).toBe(true);
       });
 
       it('should support uniqueItems', () => {
@@ -418,22 +418,22 @@ describe('Service: FormlyJsonschema', () => {
           uniqueItems: true,
         };
         const config = formlyJsonschema.toFieldConfig(numSchema);
-        expect(config.props.uniqueItems).toBeTrue();
+        expect(config.props.uniqueItems).toBe(true);
 
         const uniqueItemsValidator = (model: any) => config.validators.uniqueItems(new FormControl(model), { model });
-        expect(uniqueItemsValidator(undefined)).toBeTrue();
-        expect(uniqueItemsValidator([1, 2, 3])).toBeTrue();
-        expect(uniqueItemsValidator([1, 2, 2])).toBeFalse();
+        expect(uniqueItemsValidator(undefined)).toBe(true);
+        expect(uniqueItemsValidator([1, 2, 3])).toBe(true);
+        expect(uniqueItemsValidator([1, 2, 2])).toBe(false);
         expect(
           uniqueItemsValidator([
             { a: 2, b: 1 },
             { b: 1, a: 2 },
           ]),
-        ).toBeFalse();
+        ).toBe(false);
 
-        expect(uniqueItemsValidator([{ foo: { a: 2, b: 1 } }, { foo: { b: 1, a: 2 } }])).toBeFalse();
-        expect(uniqueItemsValidator([{ a: 2 }, { a: 1 }])).toBeTrue();
-        expect(uniqueItemsValidator([{ a: 1 }, { a: 1 }])).toBeFalse();
+        expect(uniqueItemsValidator([{ foo: { a: 2, b: 1 } }, { foo: { b: 1, a: 2 } }])).toBe(false);
+        expect(uniqueItemsValidator([{ a: 2 }, { a: 1 }])).toBe(true);
+        expect(uniqueItemsValidator([{ a: 1 }, { a: 1 }])).toBe(false);
       });
     });
 
@@ -442,11 +442,11 @@ describe('Service: FormlyJsonschema', () => {
     describe('object validation keywords', () => {
       it('should be an object value', () => {
         const f = formlyJsonschema.toFieldConfig({ type: 'object' });
-        expect(validateType(f, {})).toBeTrue();
-        expect(validateType(f, undefined)).toBeTrue();
-        expect(validateType(f, null)).toBeFalse();
-        expect(validateType(f, 5)).toBeFalse();
-        expect(validateType(f, ['sss'])).toBeFalse();
+        expect(validateType(f, {})).toBe(true);
+        expect(validateType(f, undefined)).toBe(true);
+        expect(validateType(f, null)).toBe(false);
+        expect(validateType(f, 5)).toBe(false);
+        expect(validateType(f, ['sss'])).toBe(false);
       });
 
       describe('required keyword', () => {
@@ -462,7 +462,7 @@ describe('Service: FormlyJsonschema', () => {
           });
 
           const childField = field.fieldGroup[0];
-          expect(childField.props.required).toBeTrue();
+          expect(childField.props.required).toBe(true);
         });
 
         it('nested required object with required property', () => {
@@ -483,7 +483,7 @@ describe('Service: FormlyJsonschema', () => {
           });
 
           const childField = field.fieldGroup[0].fieldGroup[0];
-          expect(childField.props.required).toBeTrue();
+          expect(childField.props.required).toBe(true);
         });
 
         it('nested optional object with required property', () => {
@@ -503,11 +503,11 @@ describe('Service: FormlyJsonschema', () => {
           });
 
           const childField = field.fieldGroup[0].fieldGroup[0];
-          expect(childField.props.required).toBeFalse();
+          expect(childField.props.required).toBe(false);
 
           childField.formControl.setValue('***');
           fixture.detectChanges();
-          expect(childField.props.required).toBeTrue();
+          expect(childField.props.required).toBe(true);
         });
 
         it('required with oneOf/anyOf', () => {
@@ -582,11 +582,11 @@ describe('Service: FormlyJsonschema', () => {
             });
 
             const [creditCardField, billingAddressField] = field.fieldGroup;
-            expect(billingAddressField.props.required).toBeTrue();
+            expect(billingAddressField.props.required).toBe(true);
 
             creditCardField.formControl.setValue(null);
             fixture.detectChanges();
-            expect(billingAddressField.props.required).toBeFalse();
+            expect(billingAddressField.props.required).toBe(false);
           });
         });
 
@@ -609,8 +609,8 @@ describe('Service: FormlyJsonschema', () => {
 
             const config = formlyJsonschema.toFieldConfig(schema).fieldGroup;
             const hideExpr = config[1].expressions.hide as any;
-            expect(hideExpr({ model: { credit_card: null } })).toBeTrue();
-            expect(hideExpr({ model: { credit_card: 121223233 } })).toBeFalse();
+            expect(hideExpr({ model: { credit_card: null } })).toBe(true);
+            expect(hideExpr({ model: { credit_card: 121223233 } })).toBe(false);
           });
           it('should display extended schema with oneOf', () => {
             const schema: JSONSchema7 = {
@@ -641,12 +641,12 @@ describe('Service: FormlyJsonschema', () => {
 
             const [, opt1Field, opt2Field] = formlyJsonschema.toFieldConfig(schema).fieldGroup;
             const opt1HideExpr = opt1Field.expressions.hide as any;
-            expect(opt1HideExpr({ model: { state: true } })).toBeFalse();
-            expect(opt1HideExpr({ model: { state: false } })).toBeTrue();
+            expect(opt1HideExpr({ model: { state: true } })).toBe(false);
+            expect(opt1HideExpr({ model: { state: false } })).toBe(true);
 
             const opt2HideExpr = opt2Field.expressions.hide as any;
-            expect(opt2HideExpr({ model: { state: true } })).toBeTrue();
-            expect(opt2HideExpr({ model: { state: false } })).toBeFalse();
+            expect(opt2HideExpr({ model: { state: true } })).toBe(true);
+            expect(opt2HideExpr({ model: { state: false } })).toBe(false);
           });
         });
       });
@@ -678,9 +678,9 @@ describe('Service: FormlyJsonschema', () => {
           expect(conditionalGroup.expressions.hide).toBeDefined();
 
           const hideExpr = conditionalGroup.expressions.hide as any;
-          expect(hideExpr({ model: { status: 'FLAG_CONTROLLED' } })).toBeFalse();
-          expect(hideExpr({ model: { status: 'ENABLED' } })).toBeTrue();
-          expect(hideExpr({ model: { status: 'DISABLED' } })).toBeTrue();
+          expect(hideExpr({ model: { status: 'FLAG_CONTROLLED' } })).toBe(false);
+          expect(hideExpr({ model: { status: 'ENABLED' } })).toBe(true);
+          expect(hideExpr({ model: { status: 'DISABLED' } })).toBe(true);
         });
 
         it('should display conditional fields based on if/else', () => {
@@ -707,8 +707,8 @@ describe('Service: FormlyJsonschema', () => {
           expect(conditionalGroup.fieldGroup[0].key).toBe('optionB');
 
           const hideExpr = conditionalGroup.expressions.hide as any;
-          expect(hideExpr({ model: { type: 'A' } })).toBeTrue(); // else is hidden when if is true
-          expect(hideExpr({ model: { type: 'B' } })).toBeFalse(); // else is shown when if is false
+          expect(hideExpr({ model: { type: 'A' } })).toBe(true); // else is hidden when if is true
+          expect(hideExpr({ model: { type: 'B' } })).toBe(false); // else is shown when if is false
         });
 
         it('should handle multiple conditional properties in then', () => {
@@ -774,15 +774,15 @@ describe('Service: FormlyJsonschema', () => {
 
           // Test then condition (zipcode shown when USA, hidden otherwise)
           const thenHideExpr = thenGroup.expressions.hide as any;
-          expect(thenHideExpr({ model: { country: 'United States of America' } })).toBeFalse();
-          expect(thenHideExpr({ model: { country: 'Canada' } })).toBeTrue();
-          expect(thenHideExpr({ model: { country: 'Other' } })).toBeTrue();
+          expect(thenHideExpr({ model: { country: 'United States of America' } })).toBe(false);
+          expect(thenHideExpr({ model: { country: 'Canada' } })).toBe(true);
+          expect(thenHideExpr({ model: { country: 'Other' } })).toBe(true);
 
           // Test else condition (postal_code hidden when USA, shown otherwise)
           const elseHideExpr = elseGroup.expressions.hide as any;
-          expect(elseHideExpr({ model: { country: 'United States of America' } })).toBeTrue();
-          expect(elseHideExpr({ model: { country: 'Canada' } })).toBeFalse();
-          expect(elseHideExpr({ model: { country: 'Other' } })).toBeFalse();
+          expect(elseHideExpr({ model: { country: 'United States of America' } })).toBe(true);
+          expect(elseHideExpr({ model: { country: 'Canada' } })).toBe(false);
+          expect(elseHideExpr({ model: { country: 'Other' } })).toBe(false);
         });
       });
     });
@@ -914,7 +914,7 @@ describe('Service: FormlyJsonschema', () => {
             const { type, validators, props } = formlyJsonschema.toFieldConfig(numSchema);
 
             expect(type).toEqual('enum');
-            expect(props.multiple).toBeTrue();
+            expect(props.multiple).toBe(true);
             expect(validators.uniqueItems).toBeDefined();
           });
 
@@ -936,7 +936,7 @@ describe('Service: FormlyJsonschema', () => {
 
             const { type, props } = formlyJsonschema.toFieldConfig(numSchema);
             expect(type).toEqual('enum');
-            expect(props.multiple).toBeTrue();
+            expect(props.multiple).toBe(true);
           });
         });
 
@@ -949,9 +949,9 @@ describe('Service: FormlyJsonschema', () => {
 
           const enumValidators = config.validators.enum;
           expect(enumValidators).toBeDefined();
-          expect(enumValidators(new FormControl(4))).toBeFalse();
-          expect(enumValidators(new FormControl(5))).toBeFalse();
-          expect(enumValidators(new FormControl(1))).toBeTrue();
+          expect(enumValidators(new FormControl(4))).toBe(false);
+          expect(enumValidators(new FormControl(5))).toBe(false);
+          expect(enumValidators(new FormControl(1))).toBe(true);
         });
       });
 
@@ -978,9 +978,9 @@ describe('Service: FormlyJsonschema', () => {
         expect(defaultValue).toBeUndefined();
 
         expect(constValidator).toBeDefined();
-        expect(constValidator(new FormControl(null))).toBeFalse();
-        expect(constValidator(new FormControl(4))).toBeFalse();
-        expect(constValidator(new FormControl('const'))).toBeTrue();
+        expect(constValidator(new FormControl(null))).toBe(false);
+        expect(constValidator(new FormControl(4))).toBe(false);
+        expect(constValidator(new FormControl('const'))).toBe(true);
       });
     });
 
@@ -1288,7 +1288,7 @@ describe('Service: FormlyJsonschema', () => {
             allOf: [{ uniqueItems: false }, { uniqueItems: true }],
           };
           const { props } = formlyJsonschema.toFieldConfig(schema);
-          expect(props.uniqueItems).toBeTrue();
+          expect(props.uniqueItems).toBe(true);
         });
 
         it('minLength', () => {
@@ -1344,8 +1344,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
         });
 
         it('should render the valid oneOf field when properties have the same name', () => {
@@ -1366,8 +1366,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(foo1Field.hide).toBeTrue();
-          expect(foo2Field.hide).toBeFalse();
+          expect(foo1Field.hide).toBe(true);
+          expect(foo2Field.hide).toBe(false);
         });
 
         it('should not share the same formControl when a prop is duplicated in oneOf', () => {
@@ -1403,15 +1403,15 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeFalse();
-          expect(barField.hide).toBeTrue();
+          expect(fooField.hide).toBe(false);
+          expect(barField.hide).toBe(true);
 
           enumField.formControl.setValue(1);
           detectChanges();
 
           expect(field.model).toEqual({});
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
         });
 
         it('should support oneOf within array', () => {
@@ -1433,8 +1433,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup[0].fieldGroup;
 
-          expect(foo1Field.hide).toBeTrue();
-          expect(foo2Field.hide).toBeFalse();
+          expect(foo1Field.hide).toBe(true);
+          expect(foo2Field.hide).toBe(false);
         });
 
         // https://github.com/ngx-formly/ngx-formly/issues/3805
@@ -1456,8 +1456,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[1].fieldGroup[0].fieldGroup;
 
-          expect(field1.hide).toBeFalse();
-          expect(field2.hide).toBeTrue();
+          expect(field1.hide).toBe(false);
+          expect(field2.hide).toBe(true);
         });
 
         it('should support oneOf with array mixed type', () => {
@@ -1484,8 +1484,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup[0].fieldGroup;
 
-          expect(foo1Field.hide).toBeTrue();
-          expect(foo2Field.hide).toBeFalse();
+          expect(foo1Field.hide).toBe(true);
+          expect(foo2Field.hide).toBe(false);
         });
 
         it('should support oneOf for a non-object type', () => {
@@ -1507,8 +1507,8 @@ describe('Service: FormlyJsonschema', () => {
               fieldGroup: [foo1Field, foo2Field],
             },
           ] = field.fieldGroup[0].fieldGroup[0].fieldGroup;
-          expect(foo1Field.hide).toBeTrue();
-          expect(foo2Field.hide).toBeFalse();
+          expect(foo1Field.hide).toBe(true);
+          expect(foo2Field.hide).toBe(false);
         });
 
         it('should support oneOf using mixed type', () => {
@@ -1576,8 +1576,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(foo1Field.hide).toBeFalse();
-          expect(foo2Field.hide).toBeTrue();
+          expect(foo1Field.hide).toBe(false);
+          expect(foo2Field.hide).toBe(true);
           expect(field.model).toEqual({ foo: 2 });
         });
 
@@ -1621,7 +1621,7 @@ describe('Service: FormlyJsonschema', () => {
           conditionSelector.formControl.setValue(1);
           detectChanges();
 
-          expect(notField.hide).toBeFalse();
+          expect(notField.hide).toBe(false);
           expect(notField.fieldGroup[0].fieldGroup[0].type).toBe('multischema');
         });
 
@@ -1643,8 +1643,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeFalse();
-          expect(barField.hide).toBeTrue();
+          expect(fooField.hide).toBe(false);
+          expect(barField.hide).toBe(true);
         });
 
         it('should take account of default value', () => {
@@ -1664,15 +1664,15 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeFalse();
-          expect(barField.hide).toBeTrue();
+          expect(fooField.hide).toBe(false);
+          expect(barField.hide).toBe(true);
           expect(field.model).toEqual({ foo: 'foo' });
 
           enumField.formControl.setValue(1);
           detectChanges();
 
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
           expect(field.model).toEqual({ bar: 'bar' });
         });
 
@@ -1694,8 +1694,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
           expect(field.model).toEqual({ bar: 'test' });
 
           enumField.formControl.setValue(0);
@@ -1730,8 +1730,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(f1.hide).toBeTrue();
-          expect(f2.hide).toBeFalse();
+          expect(f1.hide).toBe(true);
+          expect(f2.hide).toBe(false);
         });
 
         it('should render the selected oneOf field (empty array object)', () => {
@@ -1784,9 +1784,9 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(f1.props.disabled).toBeTrue();
-          expect(f1.hide).toBeTrue();
-          expect(f2.hide).toBeFalse();
+          expect(f1.props.disabled).toBe(true);
+          expect(f1.hide).toBe(true);
+          expect(f2.hide).toBe(false);
         });
 
         it('should select oneOf readOnly option when model is set', () => {
@@ -1811,9 +1811,9 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(f1.props.disabled).toBeTrue();
-          expect(f1.hide).toBeFalse();
-          expect(f2.hide).toBeTrue();
+          expect(f1.props.disabled).toBe(true);
+          expect(f1.hide).toBe(false);
+          expect(f2.hide).toBe(true);
         });
 
         it('should take account of model change after build', () => {
@@ -1870,8 +1870,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
         });
 
         it('should render the filled anyOf field on first render (matched one anyOf schema)', () => {
@@ -1893,8 +1893,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
         });
 
         it('should render the filled anyOf field on first render (matched multi anyOf schema)', () => {
@@ -1916,8 +1916,8 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeFalse();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(false);
+          expect(barField.hide).toBe(false);
         });
 
         it('should render the selected anyOf field', () => {
@@ -1929,15 +1929,15 @@ describe('Service: FormlyJsonschema', () => {
             },
           ] = field.fieldGroup[0].fieldGroup;
 
-          expect(fooField.hide).toBeFalse();
-          expect(barField.hide).toBeTrue();
+          expect(fooField.hide).toBe(false);
+          expect(barField.hide).toBe(true);
 
           enumField.formControl.setValue([1]);
           detectChanges();
 
           expect(field.model).toEqual({});
-          expect(fooField.hide).toBeTrue();
-          expect(barField.hide).toBeFalse();
+          expect(fooField.hide).toBe(true);
+          expect(barField.hide).toBe(false);
         });
 
         it('should reset the unselected anyOf field with default value', () => {

--- a/src/core/src/lib/components/formly.form.spec.ts
+++ b/src/core/src/lib/components/formly.form.spec.ts
@@ -1,5 +1,7 @@
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { FormlyInputModule, createComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormArray, FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { describe, expect, it, jest } from '@jest/globals';
 import {
   FieldType,
   FieldTypeConfig,
@@ -9,9 +11,9 @@ import {
   provideFormlyConfig,
   provideFormlyCore,
 } from '@ngx-formly/core';
-import { FormGroup, FormArray, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { createComponent, FormlyInputModule, ɵCustomEvent } from '@ngx-formly/core/testing';
+import 'jest-extended';
 import { FormlyOnPushComponent } from './formly.field.spec';
-import { Component } from '@angular/core';
 
 type IFormlyFormInputs = Partial<{
   form: FormGroup | FormArray;
@@ -320,8 +322,8 @@ describe('FormlyForm Component', () => {
       expect(barControl).not.toBeNull();
     });
 
-    it('should detect changes before emitting `modelChange`', fakeAsync(() => {
-      const { fields } = renderComponent({
+    it('should detect changes before emitting `modelChange`', async () => {
+      const { fields, fixture } = renderComponent({
         fields: [
           {
             key: 'foo',
@@ -336,9 +338,9 @@ describe('FormlyForm Component', () => {
         ],
       });
 
-      tick();
-      expect(fields[0].hide).toBeTrue();
-    }));
+      await fixture.whenStable();
+      expect(fields[0].hide).toBe(true);
+    });
 
     it('should reset field before eval expressions', () => {
       const { form, model, fields } = renderComponent(
@@ -807,12 +809,12 @@ describe('FormlyForm Component', () => {
       { extras: { checkExpressionOn: 'modelChange' } },
     );
 
-    expect(fields[0].hide).toBeFalse();
+    expect(fields[0].hide).toBe(false);
 
     query('form').triggerEventHandler('submit', {});
     detectChanges();
 
-    expect(fields[0].hide).toBeTrue();
+    expect(fields[0].hide).toBe(true);
   });
 
   it('should keep in sync UI on checkExpressionChange', () => {
@@ -836,7 +838,7 @@ describe('FormlyForm Component', () => {
     fixture.autoDetectChanges();
 
     const control = form.get('city');
-    expect(control.disabled).toBeTrue();
+    expect(control.disabled).toBe(true);
     expect(input.attributes.disabled).toEqual('disabled');
   });
 
@@ -892,7 +894,7 @@ describe('FormlyForm Component', () => {
     options.build(fields[0]);
     // NG0100: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value for 'disabled': 'false'. Current value: 'true'
     expect(detectChanges).not.toThrowError(/ExpressionChangedAfterItHasBeenCheckedError/);
-    expect(form.valid).toBeFalse();
+    expect(form.valid).toBe(false);
   });
 
   it('should update validity of all created nested FormGroup', () => {
@@ -923,7 +925,7 @@ describe('FormlyForm Component', () => {
 
     const fixture = TestBed.createComponent(StandaloneAppComponent);
     fixture.detectChanges();
-    expect(!!fixture.elementRef.nativeElement.querySelector('input')).toBeTrue();
+    expect(!!fixture.elementRef.nativeElement.querySelector('input')).toBe(true);
   });
 });
 
@@ -955,7 +957,17 @@ export class StandaloneAppComponent {}
 
 @Component({
   selector: 'formly-type-input',
-  template: ` <input type="text" [formControl]="formControl" [formlyAttributes]="field" /> `,
+  template: ` <input type="text" [formControl]="control" [formlyAttributes]="fieldConfig" /> `,
   standalone: true,
+  imports: [ReactiveFormsModule, FormlyModule],
 })
-export class FormlyFieldInput extends FieldType<FieldTypeConfig> {}
+export class FormlyFieldInput extends FieldType<FieldTypeConfig> {
+  // Explicitly typed getters bypass the complex base-class type traversal
+  get control(): FormControl {
+    return this.formControl as FormControl;
+  }
+
+  get fieldConfig() {
+    return this.field;
+  }
+}

--- a/src/core/src/lib/extensions/core/core.spec.ts
+++ b/src/core/src/lib/extensions/core/core.spec.ts
@@ -1,7 +1,8 @@
+import { describe, expect, it } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { FormlyFieldConfigCache } from '../../models';
-import { mockComponent, createBuilder, createFieldComponent, FormlyInputModule } from '@ngx-formly/core/testing';
+import { createBuilder, createFieldComponent, FormlyInputModule, mockComponent } from '@ngx-formly/core/testing';
 import { Subject } from 'rxjs';
+import { FormlyFieldConfigCache } from '../../models';
 
 function renderComponent(field: FormlyFieldConfig) {
   return createFieldComponent(field, {
@@ -79,7 +80,7 @@ describe('CoreExtension', () => {
         defaultValue: false,
       });
 
-      expect(field.model.title).toBeFalse();
+      expect(field.model.title).toBe(false);
     });
 
     it('should set the defaultValue for nested key', () => {

--- a/src/core/src/lib/extensions/field-expression-legacy/field-expression.spec.ts
+++ b/src/core/src/lib/extensions/field-expression-legacy/field-expression.spec.ts
@@ -1,7 +1,7 @@
 import { FormControl } from '@angular/forms';
+import { createBuilder } from '@ngx-formly/core/testing';
 import { Subject, of } from 'rxjs';
 import { FormlyFieldConfig, FormlyFieldConfigCache } from '../../models';
-import { createBuilder } from '@ngx-formly/core/testing';
 
 function buildField({ model, options, ...field }: FormlyFieldConfigCache): FormlyFieldConfigCache {
   const builder = createBuilder({
@@ -27,14 +27,14 @@ describe('FieldExpressionExtension', () => {
         },
       });
 
-      expect(field.hide).toBeTrue();
-      expect(field.props.hidden).toBeTrue();
+      expect(field.hide).toBe(true);
+      expect(field.props.hidden).toBe(true);
 
       field.model.visibilityToggle = 'test';
       field.options.checkExpressions(field);
 
-      expect(field.hide).toBeFalse();
-      expect(field.props.hidden).toBeFalse();
+      expect(field.hide).toBe(false);
+      expect(field.props.hidden).toBe(false);
     });
 
     it('should evaluate function expression', () => {
@@ -43,7 +43,7 @@ describe('FieldExpressionExtension', () => {
         expressions: { hide: () => true },
       });
 
-      expect(field.hide).toBeTrue();
+      expect(field.hide).toBe(true);
     });
 
     it('should evaluate boolean expression', () => {
@@ -52,7 +52,7 @@ describe('FieldExpressionExtension', () => {
         hideExpression: true,
       });
 
-      expect(field.hide).toBeTrue();
+      expect(field.hide).toBe(true);
     });
 
     it('should provide model, formState and field args', () => {
@@ -124,9 +124,9 @@ describe('FieldExpressionExtension', () => {
         const { options, fieldGroup: fields, form } = field;
 
         options.checkExpressions(field);
-        expect(fields[0].hide).toBeFalse();
+        expect(fields[0].hide).toBe(false);
         expect(fields[0].formControl).toBe(form.get('key1'));
-        expect(fields[1].hide).toBeTrue();
+        expect(fields[1].hide).toBe(true);
         expect(fields[1].formControl).toBe(form.get('key1'));
       });
 
@@ -173,16 +173,16 @@ describe('FieldExpressionExtension', () => {
         field.model.type = false;
         field.options.checkExpressions(field.parent);
 
-        expect(f1.hide).toBeFalse();
+        expect(f1.hide).toBe(false);
         expect(f1.formControl).toBe(form.get('key1'));
-        expect(f2.hide).toBeTrue();
+        expect(f2.hide).toBe(true);
         expect(f2.formControl).not.toBe(form.get('key1'));
 
         field.model.type = true;
         field.options.checkExpressions(field.parent);
-        expect(f1.hide).toBeTrue();
+        expect(f1.hide).toBe(true);
         expect(f1.formControl).not.toBe(form.get('key1'));
-        expect(f2.hide).toBeFalse();
+        expect(f2.hide).toBe(false);
         expect(f2.formControl).toBe(form.get('key1'));
       });
     });
@@ -198,8 +198,8 @@ describe('FieldExpressionExtension', () => {
         ],
       });
 
-      expect(field.hide).toBeFalse();
-      expect(field.fieldGroup[0].hide).toBeTrue();
+      expect(field.hide).toBe(false);
+      expect(field.fieldGroup[0].hide).toBe(true);
     });
 
     it('should ignore validation of hidden fields (same key)', () => {
@@ -210,7 +210,7 @@ describe('FieldExpressionExtension', () => {
       field.fieldGroup[0].hide = false;
 
       field.options.checkExpressions(field);
-      expect(field.form.valid).toBeFalse();
+      expect(field.form.valid).toBe(false);
     });
   });
 
@@ -340,12 +340,12 @@ describe('FieldExpressionExtension', () => {
           },
         });
 
-        expect(field.props.disabled).toBeFalse();
+        expect(field.props.disabled).toBe(false);
 
         field.model.disableToggle = 'test';
         field.options.checkExpressions(field);
 
-        expect(field.props.disabled).toBeTrue();
+        expect(field.props.disabled).toBe(true);
       });
 
       it('should take account of parent disabled state', () => {
@@ -368,21 +368,21 @@ describe('FieldExpressionExtension', () => {
           ],
         });
 
-        expect(field.props.disabled).toBeTrue();
-        expect(field.fieldGroup[0].props.disabled).toBeTrue();
+        expect(field.props.disabled).toBe(true);
+        expect(field.fieldGroup[0].props.disabled).toBe(true);
         expect(field.fieldGroup[1].props.label).toEqual('Street');
 
         disabled.address = false;
         field.options.checkExpressions(field);
 
-        expect(field.props.disabled).toBeFalse();
-        expect(field.fieldGroup[0].props.disabled).toBeFalse();
+        expect(field.props.disabled).toBe(false);
+        expect(field.fieldGroup[0].props.disabled).toBe(false);
 
         disabled.city = true;
         field.options.checkExpressions(field);
 
-        expect(field.props.disabled).toBeFalse();
-        expect(field.fieldGroup[0].props.disabled).toBeTrue();
+        expect(field.props.disabled).toBe(false);
+        expect(field.fieldGroup[0].props.disabled).toBe(true);
       });
 
       it('should update disabled state of hidden fields', () => {
@@ -395,14 +395,14 @@ describe('FieldExpressionExtension', () => {
           fieldGroup: [{ key: 'child', hide: true }],
         });
 
-        expect(field.props.disabled).toBeFalse();
-        expect(field.fieldGroup[0].props.disabled).toBeFalse();
+        expect(field.props.disabled).toBe(false);
+        expect(field.fieldGroup[0].props.disabled).toBe(false);
 
         field.model.disableToggle = true;
         field.options.checkExpressions(field.parent);
 
-        expect(field.props.disabled).toBeTrue();
-        expect(field.fieldGroup[0].props.disabled).toBeTrue();
+        expect(field.props.disabled).toBe(true);
+        expect(field.fieldGroup[0].props.disabled).toBe(true);
       });
 
       it('should change model through observable', () => {

--- a/src/core/src/lib/extensions/field-form/field-form.spec.ts
+++ b/src/core/src/lib/extensions/field-form/field-form.spec.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
-import { FormlyFieldConfigCache } from '../../models';
 import { createBuilder } from '@ngx-formly/core/testing';
+import { FormlyFieldConfigCache } from '../../models';
 
 function buildField({ model, options, form, ...field }: FormlyFieldConfigCache): FormlyFieldConfigCache {
   const builder = createBuilder({
@@ -63,7 +63,7 @@ describe('FieldFormExtension', () => {
     it('should assign parent form to field', () => {
       const field = buildField({ key: 'title' });
 
-      expect(field.form instanceof FormGroup).toBeTrue();
+      expect(field.form instanceof FormGroup).toBe(true);
       expect(field.form).toBe(field.parent.formControl as FormGroup);
     });
 
@@ -79,7 +79,7 @@ describe('FieldFormExtension', () => {
     it('should create formControl when key exist', () => {
       const field = buildField({ key: 'title' });
 
-      expect(field.formControl instanceof FormControl).toBeTrue();
+      expect(field.formControl instanceof FormControl).toBe(true);
     });
 
     it('should add formControl for field with empty key', () => {
@@ -119,7 +119,7 @@ describe('FieldFormExtension', () => {
     it('should create FormGroup control when fieldGroup and key are set', () => {
       const field = buildField({ key: 'test', fieldGroup: [] });
 
-      expect(field.formControl instanceof FormGroup).toBeTrue();
+      expect(field.formControl instanceof FormGroup).toBe(true);
     });
 
     it('should assign parent formcontrol when key is empty', () => {
@@ -247,7 +247,7 @@ describe('FieldFormExtension', () => {
       });
 
       const control = field.formControl;
-      expect(control.disabled).toBeTrue();
+      expect(control.disabled).toBe(true);
     });
 
     it('should disable sub-fields when parent is disabled', () => {
@@ -258,9 +258,9 @@ describe('FieldFormExtension', () => {
       });
 
       const control = field.formControl;
-      expect(control.disabled).toBeTrue();
-      expect(control.get('city').disabled).toBeTrue();
-      expect(control.get('street').disabled).toBeTrue();
+      expect(control.disabled).toBe(true);
+      expect(control.get('city').disabled).toBe(true);
+      expect(control.get('street').disabled).toBe(true);
     });
 
     it('should not affect parent disabled state', () => {
@@ -270,9 +270,9 @@ describe('FieldFormExtension', () => {
       });
 
       const control = field.formControl;
-      expect(control.disabled).toBeFalse();
-      expect(control.get('city').disabled).toBeTrue();
-      expect(control.get('street').disabled).toBeFalse();
+      expect(control.disabled).toBe(false);
+      expect(control.get('city').disabled).toBe(true);
+      expect(control.get('street').disabled).toBe(false);
     });
 
     it('should enable previously disabled control', () => {

--- a/src/core/src/lib/extensions/field-form/utils.spec.ts
+++ b/src/core/src/lib/extensions/field-form/utils.spec.ts
@@ -1,6 +1,6 @@
-import { unregisterControl, registerControl } from './utils';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import { FormlyFieldConfig } from '@ngx-formly/core';
+import { registerControl, unregisterControl } from './utils';
 
 describe('registerControl', () => {
   it('FormArray', () => {
@@ -69,16 +69,16 @@ describe('registerControl', () => {
 
     registerControl(field, new FormControl());
     field.props.disabled = true;
-    expect(field.formControl.disabled).toBeTrue();
+    expect(field.formControl.disabled).toBe(true);
 
     field.props.disabled = false;
-    expect(field.formControl.disabled).toBeFalse();
+    expect(field.formControl.disabled).toBe(false);
 
     field.formControl.disable();
-    expect(field.props.disabled).toBeTrue();
+    expect(field.props.disabled).toBe(true);
 
     field.formControl.enable();
-    expect(field.props.disabled).toBeFalse();
+    expect(field.props.disabled).toBe(false);
   });
 
   it('should replace existing control with the field one', () => {

--- a/src/core/src/lib/extensions/field-validation/field-validation.spec.ts
+++ b/src/core/src/lib/extensions/field-validation/field-validation.spec.ts
@@ -1,7 +1,7 @@
-import { FormControl, Validators, ValidationErrors, FormGroup, AbstractControl } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
+import { createBuilder } from '@ngx-formly/core/testing';
 import { of } from 'rxjs';
 import { FormlyFieldConfigCache } from '../../models';
-import { createBuilder } from '@ngx-formly/core/testing';
 
 function buildField(field: FormlyFieldConfigCache): FormlyFieldConfigCache {
   const builder = createBuilder({
@@ -99,10 +99,10 @@ describe('FieldValidationExtension: initialise field validators', () => {
     it(`should take account of programmatic changes`, () => {
       const field = buildField({});
       field.formControl = new FormControl(null, field._validators);
-      expect(field.formControl.valid).toBeTrue();
+      expect(field.formControl.valid).toBe(true);
 
       field.props.required = true;
-      expect(field.formControl.valid).toBeFalse();
+      expect(field.formControl.valid).toBe(false);
     });
 
     it(`should ignore fieldGroup with empty key`, () => {

--- a/src/core/src/lib/services/formly.builder.spec.ts
+++ b/src/core/src/lib/services/formly.builder.spec.ts
@@ -1,6 +1,6 @@
-import { FormlyFormBuilder, FormlyConfig } from '../core';
-import { ConfigOption, FormlyFieldConfigCache } from '../models';
 import { FormGroup } from '@angular/forms';
+import { FormlyConfig, FormlyFormBuilder } from '../core';
+import { ConfigOption, FormlyFieldConfigCache } from '../models';
 
 function createBuilder(option?: ConfigOption) {
   const config = new FormlyConfig();
@@ -35,7 +35,7 @@ describe('FormlyFormBuilder service', () => {
     global.console = { ...global.console, warn: jest.fn() };
     jest.spyOn(builder, 'build');
     field.options.build(field);
-    expect(builder.build).toHaveBeenCalledOnce();
+    expect(builder.build).toHaveBeenCalledTimes(1);
   });
 
   it('should call extension during build call', () => {

--- a/src/core/src/lib/services/formly.config.spec.ts
+++ b/src/core/src/lib/services/formly.config.spec.ts
@@ -1,8 +1,8 @@
-import { FormlyConfig } from './formly.config';
-import { Validators, FormControl } from '@angular/forms';
 import { Component } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
 import { FormlyFieldInput } from '@ngx-formly/core/testing';
 import { FieldType, FieldWrapper } from '../core';
+import { FormlyConfig } from './formly.config';
 
 @Component({
   selector: 'formly-test-cmp',
@@ -44,7 +44,7 @@ describe('FormlyConfig service', () => {
         formControl = new FormControl(null, Validators.required),
         options = { parentForm: { submitted: true } };
 
-      expect(config.extras.showError({ options, formControl, field } as any)).toBeTrue();
+      expect(config.extras.showError({ options, formControl, field } as any)).toBe(true);
     });
 
     it('should showError when field is touched and form is invalid', () => {
@@ -54,7 +54,7 @@ describe('FormlyConfig service', () => {
 
       formControl.markAsTouched();
 
-      expect(config.extras.showError({ options, formControl, field } as any)).toBeTrue();
+      expect(config.extras.showError({ options, formControl, field } as any)).toBe(true);
     });
 
     it('should show error when option `show` is true', () => {
@@ -62,7 +62,7 @@ describe('FormlyConfig service', () => {
         formControl = new FormControl(null, Validators.required),
         options = { parentForm: { submitted: false } };
 
-      expect(config.extras.showError({ options, formControl, field } as any)).toBeTrue();
+      expect(config.extras.showError({ options, formControl, field } as any)).toBe(true);
     });
   });
 

--- a/src/core/src/lib/templates/field-array.type.spec.ts
+++ b/src/core/src/lib/templates/field-array.type.spec.ts
@@ -1,10 +1,10 @@
-import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormlyFieldConfig } from '@ngx-formly/core';
-import { FieldArrayType } from './field-array.type';
-import { FormlyInputModule, createFieldComponent, createFieldChangesSpy } from '@ngx-formly/core/testing';
+import { Component } from '@angular/core';
 import { FormArray } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { FormlyInputModule, createFieldChangesSpy, createFieldComponent } from '@ngx-formly/core/testing';
 import { renderComponent as renderFormComponent } from '../components/formly.form.spec';
+import { FieldArrayType } from './field-array.type';
 
 const renderComponent = (field: FormlyFieldConfig, config = {}) => {
   return createFieldComponent(field, {
@@ -361,15 +361,15 @@ describe('Array Field Type', () => {
     });
 
     const { formControl } = field;
-    expect(formControl.dirty).toBeFalse();
+    expect(formControl.dirty).toBe(false);
     query('#add').triggerEventHandler('click', {});
     detectChanges();
-    expect(formControl.dirty).toBeTrue();
+    expect(formControl.dirty).toBe(true);
 
     formControl.markAsPristine();
     query('#remove-0').triggerEventHandler('click', {});
     detectChanges();
-    expect(formControl.dirty).toBeTrue();
+    expect(formControl.dirty).toBe(true);
   });
 
   it('should not mark the form dirty on Add/Remove', () => {
@@ -378,19 +378,19 @@ describe('Array Field Type', () => {
       type: 'array',
     });
 
-    expect(field.form.dirty).toBeFalse();
+    expect(field.form.dirty).toBe(false);
 
     const arrayType = query('formly-array').componentInstance as ArrayTypeComponent;
 
     arrayType.add(null, null, { markAsDirty: false });
     detectChanges();
-    expect(field.form.dirty).toBeFalse();
+    expect(field.form.dirty).toBe(false);
 
     field.form.markAsPristine();
 
     arrayType.remove(0, { markAsDirty: false });
     detectChanges();
-    expect(field.form.dirty).toBeFalse();
+    expect(field.form.dirty).toBe(false);
   });
 
   it('should not change the form control instance when chinging the field position', () => {
@@ -429,14 +429,14 @@ describe('Array Field Type', () => {
       model,
       options,
     } = field;
-    expect(cityField.hide).toBeTrue();
+    expect(cityField.hide).toBe(true);
     expect(cityField.className).toEqual('test');
 
     model[0] = 'custom';
     options.checkExpressions(cityField);
     detectChanges();
 
-    expect(cityField.hide).toBeFalse();
+    expect(cityField.hide).toBe(false);
     expect(cityField.className).toEqual('custom');
   });
 

--- a/src/core/src/lib/templates/formly.attributes.spec.ts
+++ b/src/core/src/lib/templates/formly.attributes.spec.ts
@@ -169,7 +169,7 @@ describe('FormlyAttributes Component', () => {
       });
 
       query('input').triggerEventHandler('change', ɵCustomEvent());
-      expect(field.formControl.dirty).toBeTrue();
+      expect(field.formControl.dirty).toBe(true);
     });
 
     it(`should trigger props events`, () => {
@@ -208,22 +208,22 @@ describe('FormlyAttributes Component', () => {
       const inputEl = <HTMLInputElement>query('input').nativeElement;
 
       tick();
-      expect(document.activeElement === inputEl).toBeTrue();
+      expect(document.activeElement === inputEl).toBe(true);
 
       field.focus = false;
       tick();
       detectChanges();
-      expect(document.activeElement === inputEl).toBeFalse();
+      expect(document.activeElement === inputEl).toBe(false);
     }));
 
     it('should change field focus when the element is focused or blurred', () => {
       const { query, field } = renderComponent({ focus: false });
 
       query('input').triggerEventHandler('focus', {});
-      expect(field.focus).toBeTrue();
+      expect(field.focus).toBe(true);
 
       query('input').triggerEventHandler('blur', {});
-      expect(field.focus).toBeFalse();
+      expect(field.focus).toBe(false);
     });
 
     it(`should set id to the first element only when mutliple formlyAttributes is present`, () => {
@@ -268,7 +268,7 @@ describe('FormlyAttributes Component', () => {
       field.focus = true;
       tick();
       detectChanges();
-      expect(document.activeElement === query('input').nativeElement).toBeTrue();
+      expect(document.activeElement === query('input').nativeElement).toBe(true);
     }));
   });
 });

--- a/src/core/src/lib/utils.spec.ts
+++ b/src/core/src/lib/utils.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import 'jest-extended';
 import { of } from 'rxjs';
 import { FormlyField } from './core';
 import { FormlyFieldConfig } from './models';
@@ -229,7 +230,7 @@ describe('clone', () => {
     expect(clonedFoo).toEqual(foo);
     expect(clonedFoo).not.toBe(foo);
     // method of the base class have been copied
-    expect(clonedFoo.method).toBeFunction();
+    expect(typeof clonedFoo.method).toBe('function');
     expect(clonedFoo.method()).toEqual(foo.method());
   });
   it('Deep object', () => {

--- a/src/core/src/lib/utils.spec.ts
+++ b/src/core/src/lib/utils.spec.ts
@@ -1,19 +1,20 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { of } from 'rxjs';
+import { FormlyField } from './core';
+import { FormlyFieldConfig } from './models';
 import {
-  reverseDeepMerge,
+  assignFieldValue,
   assignModelValue,
+  clone,
+  defineHiddenProp,
+  getField,
   getFieldId,
   getFieldValue,
   getKeyPath,
-  clone,
   observe,
-  assignFieldValue,
-  defineHiddenProp,
   observeDeep,
-  getField,
+  reverseDeepMerge,
 } from './utils';
-import { FormlyFieldConfig } from './models';
-import { of } from 'rxjs';
-import { FormlyField } from './core';
 
 describe('FormlyUtils service', () => {
   describe('reverseDeepMerge', () => {
@@ -31,7 +32,7 @@ describe('FormlyUtils service', () => {
 
       expect(foo['foo']).toEqual('bar');
       expect(foo['foobar']).toEqual('foobar');
-      expect(foo['date'] instanceof Date).toBeTrue();
+      expect(foo['date'] instanceof Date).toBe(true);
       expect(foo.arr).toEqual([]);
     });
   });
@@ -61,7 +62,7 @@ describe('FormlyUtils service', () => {
     it('should assign value with nested array path', () => {
       const model = {};
       assignModelValue(model, ['path', '0'], 'test');
-      expect(Array.isArray(model['path'])).toBeTrue();
+      expect(Array.isArray(model['path'])).toBe(true);
       expect(model['path'][0]).toBe('test');
     });
 
@@ -244,10 +245,10 @@ describe('clone', () => {
     const bar = new Bar('test');
     const clonedBar = clone(bar);
     expect(clonedBar).toEqual(bar);
-    expect(clonedBar === bar).toBeFalse();
+    expect(clonedBar === bar).toBe(false);
     // properties of the base class have been deep copied
     expect(clonedBar.foo).toEqual(bar.foo);
-    expect(clonedBar.foo === bar.foo).toBeFalse();
+    expect(clonedBar.foo === bar.foo).toBe(false);
   });
 
   it('Enumerable getter', () => {
@@ -257,7 +258,7 @@ describe('clone', () => {
 
     const propDescriptor = Object.getOwnPropertyDescriptor(value, 'a');
     expect(propDescriptor.get).toBeDefined();
-    expect(propDescriptor.enumerable).toBeTrue();
+    expect(propDescriptor.enumerable).toBe(true);
   });
 
   it('should use bind of the cloned object', () => {

--- a/src/ui/bootstrap/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/bootstrap/checkbox/src/checkbox.type.spec.ts
@@ -1,6 +1,6 @@
+import { FormlyBootstrapCheckboxModule } from '@ngx-formly/bootstrap/checkbox';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
-import { FormlyBootstrapCheckboxModule } from '@ngx-formly/bootstrap/checkbox';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -66,12 +66,12 @@ describe('ui-bootstrap: Checkbox Type', () => {
 
     inputDebugEl.triggerEventHandler('change', ɵCustomEvent({ checked: true }));
     detectChanges();
-    expect(changeSpy).toHaveBeenCalledOnce();
-    expect(field.formControl.value).toBeTrue();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    expect(field.formControl.value).toBe(true);
 
     inputDebugEl.triggerEventHandler('change', ɵCustomEvent({ checked: false }));
     detectChanges();
     expect(changeSpy).toHaveBeenCalledTimes(2);
-    expect(field.formControl.value).toBeFalse();
+    expect(field.formControl.value).toBe(false);
   });
 });

--- a/src/ui/bootstrap/input/src/input.type.spec.ts
+++ b/src/ui/bootstrap/input/src/input.type.spec.ts
@@ -1,6 +1,6 @@
+import { FormlyBootstrapInputModule } from '@ngx-formly/bootstrap/input';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
-import { FormlyBootstrapInputModule } from '@ngx-formly/bootstrap/input';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -93,7 +93,7 @@ describe('ui-bootstrap: Input Type', () => {
     });
 
     const { classes } = query('input[type="text"]');
-    expect(classes['is-invalid']).toBeTrue();
+    expect(classes['is-invalid']).toBe(true);
   });
 
   it('should set aria-invalid to true on invalid', () => {
@@ -120,6 +120,6 @@ describe('ui-bootstrap: Input Type', () => {
     );
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.spec.ts
+++ b/src/ui/bootstrap/multicheckbox/src/multicheckbox.type.spec.ts
@@ -1,6 +1,6 @@
+import { FormlyBootstrapMultiCheckboxModule } from '@ngx-formly/bootstrap/multicheckbox';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
-import { FormlyBootstrapMultiCheckboxModule } from '@ngx-formly/bootstrap/multicheckbox';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -37,7 +37,7 @@ describe('ui-bootstrap: MultiCheckbox Type', () => {
       },
     });
 
-    expect(query('input[type="checkbox"]').classes['is-invalid']).toBeTrue();
+    expect(query('input[type="checkbox"]').classes['is-invalid']).toBe(true);
     expect(query('input[type="checkbox"]').nativeElement.getAttribute('aria-invalid')).toBe('true');
   });
 

--- a/src/ui/bootstrap/radio/src/radio.type.spec.ts
+++ b/src/ui/bootstrap/radio/src/radio.type.spec.ts
@@ -1,6 +1,6 @@
+import { FormlyBootstrapRadioModule } from '@ngx-formly/bootstrap/radio';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
-import { FormlyBootstrapRadioModule } from '@ngx-formly/bootstrap/radio';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -37,7 +37,7 @@ describe('ui-bootstrap: Radio Type', () => {
       },
     });
 
-    expect(query('input[type="radio"]').classes['is-invalid']).toBeTrue();
+    expect(query('input[type="radio"]').classes['is-invalid']).toBe(true);
   });
 
   it('should set aria-invalid to true on invalid', () => {
@@ -92,6 +92,6 @@ describe('ui-bootstrap: Radio Type', () => {
     query('input[type="radio"]').triggerEventHandler('change', ɵCustomEvent());
     detectChanges();
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/bootstrap/textarea/src/textarea.type.spec.ts
+++ b/src/ui/bootstrap/textarea/src/textarea.type.spec.ts
@@ -1,6 +1,6 @@
+import { FormlyBootstrapTextAreaModule } from '@ngx-formly/bootstrap/textarea';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
-import { FormlyBootstrapTextAreaModule } from '@ngx-formly/bootstrap/textarea';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -39,7 +39,7 @@ describe('ui-bootstrap: Textarea Type', () => {
       props: { required: true },
     });
 
-    expect(query('textarea').classes['is-invalid']).toBeTrue();
+    expect(query('textarea').classes['is-invalid']).toBe(true);
   });
 
   it('should set aria-invalid to true on invalid', () => {
@@ -64,6 +64,6 @@ describe('ui-bootstrap: Textarea Type', () => {
     ['input', 'change'].forEach((type) => query('textarea').triggerEventHandler(type, ɵCustomEvent({ value: 'foo' })));
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ionic/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/ionic/checkbox/src/checkbox.type.spec.ts
@@ -48,7 +48,7 @@ describe('ui-ionic: Checkbox Type', () => {
     inputDebugEl.nativeElement.checked = true;
     inputDebugEl.triggerEventHandler('ionChange', ɵCustomEvent(inputDebugEl.nativeElement));
     detectChanges();
-    expect(field.formControl.value).toBeTrue();
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(field.formControl.value).toBe(true);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ionic/input/src/input.type.spec.ts
+++ b/src/ui/ionic/input/src/input.type.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyInputModule } from '@ngx-formly/ionic/input';
@@ -92,7 +93,7 @@ describe('ui-ionic: Input Type', () => {
     });
 
     const { classes } = query('ion-input');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -108,6 +109,6 @@ describe('ui-ionic: Input Type', () => {
     query('ion-input').triggerEventHandler('ionInput', ɵCustomEvent(inputEl));
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ionic/radio/src/radio.type.spec.ts
+++ b/src/ui/ionic/radio/src/radio.type.spec.ts
@@ -37,7 +37,7 @@ describe('ui-ionic: Radio Type', () => {
       },
     });
 
-    expect(query('ion-radio-group').classes['ng-invalid']).toBeTrue();
+    expect(query('ion-radio-group').classes['ng-invalid']).toBe(true);
     expect(query('formly-validation-message')).not.toBeNull();
   });
 
@@ -57,6 +57,6 @@ describe('ui-ionic: Radio Type', () => {
     query('ion-radio-group').triggerEventHandler('ionChange', ɵCustomEvent(radioEl));
     detectChanges();
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ionic/select/src/select.type.spec.ts
+++ b/src/ui/ionic/select/src/select.type.spec.ts
@@ -1,6 +1,6 @@
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { FormlySelectModule } from '@ngx-formly/ionic/select';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
+import { FormlySelectModule } from '@ngx-formly/ionic/select';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -59,6 +59,6 @@ describe('ui-ionic: Select Type', () => {
     query('ion-select').triggerEventHandler('ionChange', ɵCustomEvent(radioEl));
     detectChanges();
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ionic/textarea/src/textarea.type.spec.ts
+++ b/src/ui/ionic/textarea/src/textarea.type.spec.ts
@@ -34,7 +34,7 @@ describe('ui-ionic: Textarea Type', () => {
       props: { required: true },
     });
 
-    expect(query('ion-textarea').classes['ng-invalid']).toBeTrue();
+    expect(query('ion-textarea').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -49,6 +49,6 @@ describe('ui-ionic: Textarea Type', () => {
     inputEl.value = 'foo';
     query('ion-textarea').triggerEventHandler('ionInput', ɵCustomEvent(inputEl));
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/kendo/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/kendo/checkbox/src/checkbox.type.spec.ts
@@ -60,7 +60,7 @@ describe('ui-kendo: Checkbox Type', () => {
     });
 
     const { classes } = query('input[type="checkbox"]');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -75,12 +75,12 @@ describe('ui-kendo: Checkbox Type', () => {
 
     inputDebugEl.triggerEventHandler('change', ɵCustomEvent({ checked: true }));
     detectChanges();
-    expect(field.formControl.value).toBeTrue();
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(field.formControl.value).toBe(true);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
 
     inputDebugEl.triggerEventHandler('change', ɵCustomEvent({ checked: false }));
     detectChanges();
-    expect(field.formControl.value).toBeFalse();
+    expect(field.formControl.value).toBe(false);
     expect(changeSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/ui/kendo/input/src/input.type.spec.ts
+++ b/src/ui/kendo/input/src/input.type.spec.ts
@@ -90,7 +90,7 @@ describe('ui-kendo: Input Type', () => {
     });
 
     const { classes } = query('input[type="text"]');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -106,6 +106,6 @@ describe('ui-kendo: Input Type', () => {
     );
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/kendo/radio/src/radio.type.spec.ts
+++ b/src/ui/kendo/radio/src/radio.type.spec.ts
@@ -37,7 +37,7 @@ describe('ui-kendo: Radio Type', () => {
       },
     });
 
-    expect(query('input[type="radio"]').classes['ng-invalid']).toBeTrue();
+    expect(query('input[type="radio"]').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -54,6 +54,6 @@ describe('ui-kendo: Radio Type', () => {
     query('input[type="radio"]').triggerEventHandler('change', ɵCustomEvent());
     detectChanges();
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/kendo/select/src/select.type.spec.ts
+++ b/src/ui/kendo/select/src/select.type.spec.ts
@@ -1,7 +1,7 @@
-import { FormlyFieldConfig } from '@ngx-formly/core';
-import { FormlySelectModule } from '@ngx-formly/kendo/select';
-import { createFieldComponent } from '@ngx-formly/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { createFieldComponent } from '@ngx-formly/core/testing';
+import { FormlySelectModule } from '@ngx-formly/kendo/select';
 import { POPUP_CONTAINER } from '@progress/kendo-angular-popup';
 
 const renderComponent = (field: FormlyFieldConfig) => {
@@ -72,6 +72,6 @@ describe('ui-kendo: Select Type', () => {
     query<HTMLElement>('kendo-dropdownlist').nativeElement.click();
     document.querySelector<HTMLLIElement>('.k-list-item').click();
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/kendo/textarea/src/textarea.type.spec.ts
+++ b/src/ui/kendo/textarea/src/textarea.type.spec.ts
@@ -31,7 +31,7 @@ describe('ui-kendo: Textarea Type', () => {
       props: { required: true },
     });
 
-    expect(query('textarea').classes['ng-invalid']).toBeTrue();
+    expect(query('textarea').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -45,6 +45,6 @@ describe('ui-kendo: Textarea Type', () => {
     ['input', 'change'].forEach((type) => query('textarea').triggerEventHandler(type, ɵCustomEvent({ value: 'foo' })));
     detectChanges();
     // expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/material/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/material/checkbox/src/checkbox.type.spec.ts
@@ -1,7 +1,7 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyMatCheckboxModule } from '@ngx-formly/material/checkbox';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -52,12 +52,12 @@ describe('ui-material: Checkbox Type', () => {
     const input = query('input[type="checkbox"]').nativeElement as HTMLInputElement;
     input.click();
     detectChanges();
-    expect(field.formControl.value).toBeTrue();
+    expect(field.formControl.value).toBe(true);
     expect(changeSpy).toHaveBeenCalledTimes(2);
 
     input.click();
     detectChanges();
-    expect(field.formControl.value).toBeFalse();
+    expect(field.formControl.value).toBe(false);
     expect(changeSpy).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/ui/material/input/src/input.type.spec.ts
+++ b/src/ui/material/input/src/input.type.spec.ts
@@ -1,7 +1,7 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyMatInputModule } from '@ngx-formly/material/input';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -86,7 +86,7 @@ describe('ui-material: Input Type', () => {
     });
 
     const { classes } = query('input[type="text"]');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -102,6 +102,6 @@ describe('ui-material: Input Type', () => {
     );
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/material/radio/src/radio.type.spec.ts
+++ b/src/ui/material/radio/src/radio.type.spec.ts
@@ -1,7 +1,7 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyMatRadioModule } from '@ngx-formly/material/radio';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -38,7 +38,7 @@ describe('ui-material: Radio Type', () => {
       },
     });
 
-    expect(query('mat-radio-group').classes['ng-invalid']).toBeTrue();
+    expect(query('mat-radio-group').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {

--- a/src/ui/material/select/src/select.type.spec.ts
+++ b/src/ui/material/select/src/select.type.spec.ts
@@ -1,10 +1,8 @@
-import { fakeAsync, tick } from '@angular/core/testing';
-import { createFieldComponent } from '@ngx-formly/core/testing';
-import { FormlyFieldConfig } from '@ngx-formly/core';
-import { of } from 'rxjs';
-import { timeout } from 'rxjs/operators';
-import { FormlyMatSelectModule } from '@ngx-formly/material/select';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { createFieldComponent } from '@ngx-formly/core/testing';
+import { FormlyMatSelectModule } from '@ngx-formly/material/select';
+import { of } from 'rxjs';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -78,7 +76,7 @@ describe('ui-material: Formly Field Select Component', () => {
     selectAllOption.triggerEventHandler('click', {});
     detectChanges();
     expect(field.formControl.value).toEqual(2);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 
   describe('render select options', () => {

--- a/src/ui/material/textarea/src/textarea.type.spec.ts
+++ b/src/ui/material/textarea/src/textarea.type.spec.ts
@@ -1,7 +1,7 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyMatTextAreaModule } from '@ngx-formly/material/textarea';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -41,7 +41,7 @@ describe('ui-material: Textarea Type', () => {
       props: { required: true },
     });
 
-    expect(query('textarea').classes['ng-invalid']).toBeTrue();
+    expect(query('textarea').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -55,6 +55,6 @@ describe('ui-material: Textarea Type', () => {
     ['input', 'change'].forEach((type) => query('textarea').triggerEventHandler(type, ɵCustomEvent({ value: 'foo' })));
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ng-zorro-antd/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/ng-zorro-antd/checkbox/src/checkbox.type.spec.ts
@@ -1,7 +1,8 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyNzCheckboxModule } from '@ngx-formly/ng-zorro-antd/checkbox';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -54,12 +55,12 @@ describe('ui-ng-zorro-antd: Checkbox Type', () => {
 
     inputDebugEl.triggerEventHandler('change', ɵCustomEvent({ checked: true }));
     detectChanges();
-    expect(field.formControl.value).toBeTrue();
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(field.formControl.value).toBe(true);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
 
     inputDebugEl.triggerEventHandler('change', ɵCustomEvent({ checked: false }));
     detectChanges();
-    expect(field.formControl.value).toBeFalse();
+    expect(field.formControl.value).toBe(false);
     expect(changeSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/ui/ng-zorro-antd/form-field/src/form-field.wrapper.spec.ts
+++ b/src/ui/ng-zorro-antd/form-field/src/form-field.wrapper.spec.ts
@@ -1,7 +1,8 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyNzFormFieldModule } from '@ngx-formly/ng-zorro-antd/form-field';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {

--- a/src/ui/ng-zorro-antd/input/src/input.type.spec.ts
+++ b/src/ui/ng-zorro-antd/input/src/input.type.spec.ts
@@ -1,7 +1,7 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyNzInputModule } from '@ngx-formly/ng-zorro-antd/input';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -86,7 +86,7 @@ describe('ui-ng-zorro-antd: Input Type', () => {
     });
 
     const { classes } = query('input[type="text"]');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -102,6 +102,6 @@ describe('ui-ng-zorro-antd: Input Type', () => {
     );
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ng-zorro-antd/radio/src/radio.type.spec.ts
+++ b/src/ui/ng-zorro-antd/radio/src/radio.type.spec.ts
@@ -1,7 +1,8 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyNzRadioModule } from '@ngx-formly/ng-zorro-antd/radio';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -39,7 +40,7 @@ describe('ui-ng-zorro-antd: Radio Type', () => {
       },
     });
 
-    expect(query('nz-radio-group').classes['ng-invalid']).toBeTrue();
+    expect(query('nz-radio-group').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -56,6 +57,6 @@ describe('ui-ng-zorro-antd: Radio Type', () => {
     (query('label[nz-radio]').nativeElement as HTMLElement).click();
     detectChanges();
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/ng-zorro-antd/select/src/select.type.spec.ts
+++ b/src/ui/ng-zorro-antd/select/src/select.type.spec.ts
@@ -1,4 +1,3 @@
-import { fakeAsync, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
@@ -12,7 +11,7 @@ const renderComponent = (field: FormlyFieldConfig) => {
 };
 
 describe('ui-ng-zorro-antd: Select Type', () => {
-  it('should render select type', fakeAsync(() => {
+  it('should render select type', async () => {
     const { query, queryAll, fixture } = renderComponent({
       key: 'name',
       type: 'select',
@@ -28,12 +27,12 @@ describe('ui-ng-zorro-antd: Select Type', () => {
     expect(query('formly-wrapper-nz-form-field')).not.toBeNull();
     (query('nz-select').nativeElement as HTMLElement).click();
     fixture.autoDetectChanges();
-    tick(500);
+    await fixture.whenStable();
 
     expect(queryAll('nz-option-item')).toHaveLength(3);
-  }));
+  });
 
-  it('should render enum type', fakeAsync(() => {
+  it('should render enum type', async () => {
     const { query, queryAll, fixture } = renderComponent({
       key: 'name',
       type: 'enum',
@@ -50,12 +49,12 @@ describe('ui-ng-zorro-antd: Select Type', () => {
 
     (query('nz-select').nativeElement as HTMLElement).click();
     fixture.autoDetectChanges();
-    tick(500);
+    await fixture.whenStable();
 
     expect(queryAll('nz-option-item')).toHaveLength(3);
-  }));
+  });
 
-  it('should bind control value on change', fakeAsync(() => {
+  it('should bind control value on change', async () => {
     const changeSpy = jest.fn();
     const { query, field, fixture } = renderComponent({
       key: 'name',
@@ -68,12 +67,12 @@ describe('ui-ng-zorro-antd: Select Type', () => {
 
     (query('nz-select').nativeElement as HTMLElement).click();
     fixture.autoDetectChanges();
-    tick(500);
+    await fixture.whenStable();
 
     (query('nz-option-item').nativeElement as HTMLElement).click();
     fixture.detectChanges();
-    tick(500);
+    await fixture.whenStable();
     expect(field.formControl.value).toEqual(1);
     expect(changeSpy).toHaveBeenCalledTimes(1);
-  }));
+  });
 });

--- a/src/ui/ng-zorro-antd/select/src/select.type.spec.ts
+++ b/src/ui/ng-zorro-antd/select/src/select.type.spec.ts
@@ -1,8 +1,9 @@
-import { FormlyFieldConfig } from '@ngx-formly/core';
-import { FormlyNzSelectModule } from '@ngx-formly/ng-zorro-antd/select';
-import { createFieldComponent } from '@ngx-formly/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it, jest } from '@jest/globals';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { createFieldComponent } from '@ngx-formly/core/testing';
+import { FormlyNzSelectModule } from '@ngx-formly/ng-zorro-antd/select';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -73,6 +74,6 @@ describe('ui-ng-zorro-antd: Select Type', () => {
     fixture.detectChanges();
     tick(500);
     expect(field.formControl.value).toEqual(1);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   }));
 });

--- a/src/ui/ng-zorro-antd/textarea/src/textarea.type.spec.ts
+++ b/src/ui/ng-zorro-antd/textarea/src/textarea.type.spec.ts
@@ -1,7 +1,8 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyNzTextAreaModule } from '@ngx-formly/ng-zorro-antd/textarea';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -35,7 +36,7 @@ describe('ui-ng-zorro-antd: Textarea Type', () => {
       props: { required: true },
     });
 
-    expect(query('textarea').classes['ng-invalid']).toBeTrue();
+    expect(query('textarea').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -49,6 +50,6 @@ describe('ui-ng-zorro-antd: Textarea Type', () => {
     ['input', 'change'].forEach((type) => query('textarea').triggerEventHandler(type, ɵCustomEvent({ value: 'foo' })));
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/primeng/checkbox/src/checkbox.type.spec.ts
+++ b/src/ui/primeng/checkbox/src/checkbox.type.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyCheckboxModule } from '@ngx-formly/primeng/checkbox';
@@ -45,12 +46,12 @@ describe('ui-primeng: Checkbox Type', () => {
 
     inputElm.click();
     detectChanges();
-    expect(field.formControl.value).toBeTrue();
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(field.formControl.value).toBe(true);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
 
     inputElm.click();
     detectChanges();
-    expect(field.formControl.value).toBeFalse();
+    expect(field.formControl.value).toBe(false);
     expect(changeSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/ui/primeng/datepicker/src/datepicker.type.spec.ts
+++ b/src/ui/primeng/datepicker/src/datepicker.type.spec.ts
@@ -1,5 +1,6 @@
 import { formatDate } from '@angular/common';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyDatepickerModule } from '@ngx-formly/primeng/datepicker';
@@ -32,7 +33,7 @@ describe('ui-primeng: Date Picker Type', () => {
     });
 
     const { classes } = query('p-datepicker');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should render control value on correct date format', () => {

--- a/src/ui/primeng/form-field/src/form-field.wrapper.spec.ts
+++ b/src/ui/primeng/form-field/src/form-field.wrapper.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent } from '@ngx-formly/core/testing';
 import { FormlyFormFieldModule } from '@ngx-formly/primeng/form-field';

--- a/src/ui/primeng/input/src/input.type.spec.ts
+++ b/src/ui/primeng/input/src/input.type.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyInputModule } from '@ngx-formly/primeng/input';
@@ -88,7 +89,7 @@ describe('ui-primeng: Input Type', () => {
     });
 
     const { classes } = query('input[type="text"]');
-    expect(classes['ng-invalid']).toBeTrue();
+    expect(classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -104,6 +105,6 @@ describe('ui-primeng: Input Type', () => {
     );
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/primeng/radio/src/radio.type.spec.ts
+++ b/src/ui/primeng/radio/src/radio.type.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyRadioModule } from '@ngx-formly/primeng/radio';
@@ -37,7 +38,7 @@ describe('ui-primeng: Radio Type', () => {
       },
     });
 
-    expect(query('p-radioButton').classes['ng-invalid']).toBeTrue();
+    expect(query('p-radioButton').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {

--- a/src/ui/primeng/select/src/select.type.spec.ts
+++ b/src/ui/primeng/select/src/select.type.spec.ts
@@ -1,7 +1,8 @@
-import { FormlyFieldConfig } from '@ngx-formly/core';
-import { FormlySelectModule } from '@ngx-formly/primeng/select';
-import { createFieldComponent } from '@ngx-formly/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { describe, expect, it, jest } from '@jest/globals';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { createFieldComponent } from '@ngx-formly/core/testing';
+import { FormlySelectModule } from '@ngx-formly/primeng/select';
 
 const renderComponent = (field: FormlyFieldConfig) => {
   return createFieldComponent(field, {
@@ -70,7 +71,7 @@ describe('ui-primeng: Select Type', () => {
     detectChanges();
     queryAll('p-selectItem>li')[1].triggerEventHandler('click', {});
     expect(field.formControl.value).toEqual(2);
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should filter results on search', () => {

--- a/src/ui/primeng/textarea/src/textarea.type.spec.ts
+++ b/src/ui/primeng/textarea/src/textarea.type.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { createFieldComponent, ɵCustomEvent } from '@ngx-formly/core/testing';
 import { FormlyTextAreaModule } from '@ngx-formly/primeng/textarea';
@@ -30,7 +31,7 @@ describe('ui-primeng: Textarea Type', () => {
       props: { required: true },
     });
 
-    expect(query('textarea').classes['ng-invalid']).toBeTrue();
+    expect(query('textarea').classes['ng-invalid']).toBe(true);
   });
 
   it('should bind control value on change', () => {
@@ -44,6 +45,6 @@ describe('ui-primeng: Textarea Type', () => {
     ['input', 'change'].forEach((type) => query('textarea').triggerEventHandler(type, ɵCustomEvent({ value: 'foo' })));
     detectChanges();
     expect(field.formControl.value).toEqual('foo');
-    expect(changeSpy).toHaveBeenCalledOnce();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Refactor of the testing files


**What is the current behavior? (You can also link to an open issue here)**
When opening a file, typescript isn't happy with the file, due to 

1. Missing import
2. Usage of `tick()`
3. `toBeFalse()` & `toBeTrue()`
4. Missing type
5. `toHaveBeenCalledOnce()`
6. `toBeFunction()`


**What is the new behavior (if this is a feature change)?**
1. Import from `@jest/globals` the missing declaration (`import { describe, expect, it, jest } from '@jest/globals';`)
2. -> `await fixture.whenStable();`
3. -> `.toBe(false)` & `.toBe(true)`
4. 
```
export class FormlyFieldInput extends FieldType<FieldTypeConfig> {
  // Explicitly typed getters bypass the complex base-class type traversal
  get control(): FormControl {
    return this.formControl as FormControl;
  }

  get fieldConfig() {
    return this.field;
  }
}
```
5. -> `toHaveBeenCalledTimes(1)`
6. -> `expect(typeof clonedFoo.method).toBe('function');`


**Please check if the PR fulfills these requirements**
- [x] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] A unit test has been written for this change.
- [x] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [x] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)